### PR TITLE
chore: normalize scaffold line endings and BOMs

### DIFF
--- a/src/CodeRag.Cli/AssemblyMarker.cs
+++ b/src/CodeRag.Cli/AssemblyMarker.cs
@@ -1,3 +1,3 @@
-namespace CodeRag.Cli;
+﻿namespace CodeRag.Cli;
 
 public static class AssemblyMarker;

--- a/src/CodeRag.Cli/Program.cs
+++ b/src/CodeRag.Cli/Program.cs
@@ -1,4 +1,4 @@
-using CodeRag.Core;
+﻿using CodeRag.Core;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddCoreServices();

--- a/tests/CodeRag.Tests.Architecture/LayerDependencyTests.cs
+++ b/tests/CodeRag.Tests.Architecture/LayerDependencyTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using FluentAssertions;
 using NetArchTest.Rules;
 

--- a/tests/CodeRag.Tests.Architecture/TestHelpers.cs
+++ b/tests/CodeRag.Tests.Architecture/TestHelpers.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 
 namespace CodeRag.Tests.Architecture;


### PR DESCRIPTION
## Summary
- Closes #2
- Pure dotnet format output: CRLF line endings + UTF-8 BOMs added to the four files missing them
- Unblocks the pre-commit hook for all subsequent work

## Test plan
- [x] dotnet format --verify-no-changes passes
- [x] dotnet build clean
- [x] dotnet test (20 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)