### PR TITLE
feat: coderag query verb (#9)

### DIFF
--- a/src/CodeRag.Cli/Commands/QueryCommand.cs
+++ b/src/CodeRag.Cli/Commands/QueryCommand.cs
@@ -1,0 +1,82 @@
+﻿using System.Globalization;
+using System.Text.Json;
+using CodeRag.Core.Indexing;
+using CodeRag.Core.Indexing.Interfaces;
+
+namespace CodeRag.Cli.Commands;
+
+internal sealed class QueryCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly IQueryService _queryService;
+
+    public QueryCommand(IQueryService queryService)
+    {
+        _queryService = queryService;
+    }
+
+    public async Task<int> ExecuteAsync(
+        string text,
+        string? dbPath,
+        int topK,
+        string? kind,
+        string? project,
+        string? containingNamespace,
+        bool? isAsync,
+        string format,
+        CancellationToken cancellationToken)
+    {
+        if (Environment.GetEnvironmentVariable("OPENAI_API_KEY") is null)
+        {
+            await Console.Error.WriteLineAsync("OPENAI_API_KEY is not set.");
+            return 2;
+        }
+
+        var resolvedDb = dbPath ?? Path.Combine(Directory.GetCurrentDirectory(), ".coderag", "index.db");
+        if (!File.Exists(resolvedDb))
+        {
+            await Console.Error.WriteLineAsync($"Index not found: {resolvedDb}");
+            return 2;
+        }
+
+        var filters = new QueryFilters(kind, project, containingNamespace, isAsync);
+        var request = new QueryRequest(resolvedDb, text, topK, filters);
+        var hits = await _queryService.Run(request, cancellationToken);
+
+        if (string.Equals(format, "json", StringComparison.OrdinalIgnoreCase))
+        {
+            WriteJson(hits);
+        }
+        else
+        {
+            WriteText(hits);
+        }
+        return 0;
+    }
+
+    private static void WriteJson(IReadOnlyList<QueryHit> hits)
+    {
+        var json = JsonSerializer.Serialize(hits, JsonOptions);
+        Console.WriteLine(json);
+    }
+
+    private static void WriteText(IReadOnlyList<QueryHit> hits)
+    {
+        foreach (var hit in hits)
+        {
+            var header = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}:{1}-{2}  {3}  ({4}, dist={5:F4})",
+                hit.RelativeFilePath,
+                hit.LineStart,
+                hit.LineEnd,
+                hit.FullyQualifiedSymbolName,
+                hit.SymbolKind,
+                hit.Distance);
+            Console.WriteLine(header);
+            Console.WriteLine(hit.SourceText);
+            Console.WriteLine(new string('-', 60));
+        }
+    }
+}

--- a/src/CodeRag.Cli/Program.cs
+++ b/src/CodeRag.Cli/Program.cs
@@ -6,6 +6,7 @@ using CodeRag.Core;
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddCoreServices();
 builder.Services.AddTransient<IndexCommand>();
+builder.Services.AddTransient<QueryCommand>();
 var host = builder.Build();
 
 var slnArg = new Argument<FileInfo>("solution", "Path to the .sln or .slnx file.");
@@ -22,7 +23,40 @@ indexCmd.SetHandler(async (InvocationContext ctx) =>
     ctx.ExitCode = await command.ExecuteAsync(sln.FullName, outDir?.FullName, ctx.GetCancellationToken());
 });
 
+var textArg = new Argument<string>("text", "Natural-language query.");
+var dbOpt = new Option<FileInfo?>("--db", "Path to index.db; defaults to ./.coderag/index.db");
+var topKOpt = new Option<int>("--top-k", () => 10, "Number of hits to return.");
+var kindOpt = new Option<string?>("--kind", "Filter by symbol_kind (e.g. method, class, property).");
+var projectOpt = new Option<string?>("--project", "Filter by containing project name.");
+var nsOpt = new Option<string?>("--namespace", "Filter by containing namespace.");
+var asyncOpt = new Option<bool?>("--is-async", "Filter to async methods only.");
+var formatOpt = new Option<string>("--format", () => "text", "Output format: text or json.");
+
+var queryCmd = new Command("query", "Search the code index for chunks similar to a natural-language query.");
+queryCmd.AddArgument(textArg);
+queryCmd.AddOption(dbOpt);
+queryCmd.AddOption(topKOpt);
+queryCmd.AddOption(kindOpt);
+queryCmd.AddOption(projectOpt);
+queryCmd.AddOption(nsOpt);
+queryCmd.AddOption(asyncOpt);
+queryCmd.AddOption(formatOpt);
+queryCmd.SetHandler(async (InvocationContext ctx) =>
+{
+    var text = ctx.ParseResult.GetValueForArgument(textArg);
+    var db = ctx.ParseResult.GetValueForOption(dbOpt);
+    var topK = ctx.ParseResult.GetValueForOption(topKOpt);
+    var kind = ctx.ParseResult.GetValueForOption(kindOpt);
+    var project = ctx.ParseResult.GetValueForOption(projectOpt);
+    var ns = ctx.ParseResult.GetValueForOption(nsOpt);
+    var isAsync = ctx.ParseResult.GetValueForOption(asyncOpt);
+    var format = ctx.ParseResult.GetValueForOption(formatOpt) ?? "text";
+    var command = host.Services.GetRequiredService<QueryCommand>();
+    ctx.ExitCode = await command.ExecuteAsync(text, db?.FullName, topK, kind, project, ns, isAsync, format, ctx.GetCancellationToken());
+});
+
 var rootCommand = new RootCommand("CodeRag — code RAG indexer");
 rootCommand.AddCommand(indexCmd);
+rootCommand.AddCommand(queryCmd);
 
 return await rootCommand.InvokeAsync(args);

--- a/src/CodeRag.Core/Indexing/IIndexStore.cs
+++ b/src/CodeRag.Core/Indexing/IIndexStore.cs
@@ -17,4 +17,10 @@ internal interface IIndexStore : IDisposable
     Task<IReadOnlyList<StoredChunkSummary>> GetChunkSummariesForFileAsync(string relativeFilePath, CancellationToken cancellationToken);
     Task DeleteChunkAsync(long chunkId, CancellationToken cancellationToken);
     Task DeleteChunksForFileAsync(string relativeFilePath, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<QueryHit>> Search(
+        ReadOnlyMemory<float> queryVector,
+        QueryFilters filters,
+        int topK,
+        CancellationToken cancellationToken);
 }

--- a/src/CodeRag.Core/Indexing/Interfaces/IQueryService.cs
+++ b/src/CodeRag.Core/Indexing/Interfaces/IQueryService.cs
@@ -1,0 +1,6 @@
+﻿namespace CodeRag.Core.Indexing.Interfaces;
+
+public interface IQueryService
+{
+    Task<IReadOnlyList<QueryHit>> Run(QueryRequest request, CancellationToken cancellationToken);
+}

--- a/src/CodeRag.Core/Indexing/QueryFilters.cs
+++ b/src/CodeRag.Core/Indexing/QueryFilters.cs
@@ -1,0 +1,7 @@
+﻿namespace CodeRag.Core.Indexing;
+
+public sealed record QueryFilters(
+    string? SymbolKind,
+    string? ContainingProjectName,
+    string? ContainingNamespace,
+    bool? IsAsync);

--- a/src/CodeRag.Core/Indexing/QueryHit.cs
+++ b/src/CodeRag.Core/Indexing/QueryHit.cs
@@ -1,0 +1,11 @@
+﻿namespace CodeRag.Core.Indexing;
+
+public sealed record QueryHit(
+    long ChunkId,
+    string RelativeFilePath,
+    int LineStart,
+    int LineEnd,
+    string FullyQualifiedSymbolName,
+    string SymbolKind,
+    double Distance,
+    string SourceText);

--- a/src/CodeRag.Core/Indexing/QueryRequest.cs
+++ b/src/CodeRag.Core/Indexing/QueryRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace CodeRag.Core.Indexing;
+
+public sealed record QueryRequest(
+    string IndexDatabasePath,
+    string Text,
+    int TopK,
+    QueryFilters Filters);

--- a/src/CodeRag.Core/Indexing/QueryService.cs
+++ b/src/CodeRag.Core/Indexing/QueryService.cs
@@ -1,0 +1,26 @@
+﻿using CodeRag.Core.Indexing.Interfaces;
+
+namespace CodeRag.Core.Indexing;
+
+internal sealed class QueryService : IQueryService
+{
+    private readonly IEmbeddingClient _embeddingClient;
+    private readonly Func<string, IIndexStore> _storeFactory;
+
+    public QueryService(IEmbeddingClient embeddingClient, Func<string, IIndexStore> storeFactory)
+    {
+        _embeddingClient = embeddingClient;
+        _storeFactory = storeFactory;
+    }
+
+    public async Task<IReadOnlyList<QueryHit>> Run(QueryRequest request, CancellationToken cancellationToken)
+    {
+        var inputs = new[] { request.Text };
+        var vectors = await _embeddingClient.Embed(inputs, cancellationToken);
+        var queryVector = vectors[0];
+
+        using var store = _storeFactory(request.IndexDatabasePath);
+        await store.OpenAsync(cancellationToken);
+        return await store.Search(queryVector, request.Filters, request.TopK, cancellationToken);
+    }
+}

--- a/src/CodeRag.Core/Indexing/SqliteIndexStore.cs
+++ b/src/CodeRag.Core/Indexing/SqliteIndexStore.cs
@@ -583,4 +583,77 @@ internal sealed class SqliteIndexStore : IIndexStore
         }
         return list;
     }
+
+    public async Task<IReadOnlyList<QueryHit>> Search(
+        ReadOnlyMemory<float> queryVector,
+        QueryFilters filters,
+        int topK,
+        CancellationToken cancellationToken)
+    {
+        var oversample = Math.Max(topK * 20, 200);
+        await using var cmd = Connection.CreateCommand();
+        cmd.Transaction = _transaction;
+        cmd.CommandText = SearchSql;
+        BindSearchParameters(cmd, queryVector, filters, topK, oversample);
+        return await ReadSearchResults(cmd, cancellationToken);
+    }
+
+    private static void BindSearchParameters(
+        SqliteCommand cmd,
+        ReadOnlyMemory<float> queryVector,
+        QueryFilters filters,
+        int topK,
+        int oversample)
+    {
+        cmd.Parameters.AddWithValue("$query_vector", FloatArrayToBlob(queryVector.Span));
+        cmd.Parameters.AddWithValue("$oversample", oversample);
+        cmd.Parameters.AddWithValue("$top_k", topK);
+        cmd.Parameters.AddWithValue("$symbol_kind", (object?)filters.SymbolKind ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$project", (object?)filters.ContainingProjectName ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$namespace", (object?)filters.ContainingNamespace ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$is_async", filters.IsAsync.HasValue ? (filters.IsAsync.Value ? 1 : 0) : DBNull.Value);
+    }
+
+    private static async Task<IReadOnlyList<QueryHit>> ReadSearchResults(SqliteCommand cmd, CancellationToken cancellationToken)
+    {
+        var results = new List<QueryHit>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            results.Add(new QueryHit(
+                ChunkId: reader.GetInt64(0),
+                RelativeFilePath: reader.GetString(1),
+                LineStart: reader.GetInt32(2),
+                LineEnd: reader.GetInt32(3),
+                FullyQualifiedSymbolName: reader.GetString(4),
+                SymbolKind: reader.GetString(5),
+                Distance: reader.GetDouble(6),
+                SourceText: reader.GetString(7)));
+        }
+        return results;
+    }
+
+    private const string SearchSql = @"WITH candidates AS (
+    SELECT rowid, distance
+    FROM chunk_embeddings
+    WHERE embedding MATCH $query_vector
+    ORDER BY distance
+    LIMIT $oversample
+)
+SELECT c.chunk_id,
+       c.relative_file_path,
+       c.start_line_number,
+       c.end_line_number,
+       c.fully_qualified_symbol_name,
+       c.symbol_kind,
+       cand.distance,
+       c.source_text
+FROM candidates cand
+JOIN code_chunks c ON c.chunk_id = cand.rowid
+WHERE ($symbol_kind IS NULL OR c.symbol_kind = $symbol_kind)
+  AND ($project IS NULL OR c.containing_project_name = $project)
+  AND ($namespace IS NULL OR c.containing_namespace = $namespace)
+  AND ($is_async IS NULL OR c.is_async = $is_async)
+ORDER BY cand.distance
+LIMIT $top_k";
 }

--- a/src/CodeRag.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeRag.Core/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<Func<string, IIndexStore>>(_ => path => new SqliteIndexStore(path));
         services.AddTransient<IndexingDependencies>();
         services.AddTransient<IIndexingService, IndexingService>();
+        services.AddTransient<IQueryService, QueryService>();
         return services;
     }
 }

--- a/tests/CodeRag.Tests.Integration/Core/Indexing/QueryServiceTests.cs
+++ b/tests/CodeRag.Tests.Integration/Core/Indexing/QueryServiceTests.cs
@@ -1,0 +1,88 @@
+﻿using CodeRag.Core.Indexing;
+using CodeRag.Tests.Integration.Core.Indexing.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace CodeRag.Tests.Integration.Core.Indexing;
+
+[TestFixture]
+public class QueryServiceTests
+{
+    private SampleSolutionFixture _fixture = null!;
+    private FakeEmbeddingClient _embedding = null!;
+    private StubGitDiffService _git = null!;
+    private MsBuildWorkspaceLoadingService _workspaceLoadingService = null!;
+    private string _dbPath = null!;
+    private QueryService _queryService = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _fixture = new SampleSolutionFixture();
+        _embedding = new FakeEmbeddingClient();
+        _git = new StubGitDiffService();
+        _dbPath = Path.Combine(_fixture.Root, ".coderag", "index.db");
+
+        _workspaceLoadingService = new MsBuildWorkspaceLoadingService();
+        var hashingService = new SourceTextHashingService();
+        var extractor = new ChunkExtractor(hashingService);
+        var reconciliationService = new ReconciliationService();
+        Func<string, IIndexStore> storeFactory = path => new SqliteIndexStore(path);
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 5, 2, 12, 0, 0, TimeSpan.Zero));
+
+        var deps = new IndexingDependencies(
+            _workspaceLoadingService,
+            extractor,
+            _git,
+            _embedding,
+            storeFactory,
+            reconciliationService,
+            clock);
+
+        var indexingService = new IndexingService(deps);
+        await indexingService.Run(new IndexRunRequest(_fixture.SolutionPath, _dbPath), CancellationToken.None);
+
+        _queryService = new QueryService(_embedding, storeFactory);
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await _workspaceLoadingService.DisposeAsync();
+        _fixture.Dispose();
+    }
+
+    [Test]
+    public async Task Should_return_chunks_ranked_by_embedding_similarity()
+    {
+        var hits = await _queryService.Run(
+            new QueryRequest(_dbPath, "find a user by name", 5, new QueryFilters(null, null, null, null)),
+            CancellationToken.None);
+
+        hits.Should().NotBeEmpty();
+        hits.Should().BeInAscendingOrder(h => h.Distance);
+        hits.Count.Should().BeLessThanOrEqualTo(5);
+    }
+
+    [Test]
+    public async Task Should_apply_symbol_kind_filter()
+    {
+        var hits = await _queryService.Run(
+            new QueryRequest(_dbPath, "look up a record", 10, new QueryFilters("method", null, null, null)),
+            CancellationToken.None);
+
+        hits.Should().NotBeEmpty();
+        hits.Should().OnlyContain(h => h.SymbolKind == "method");
+    }
+
+    [Test]
+    public async Task Should_apply_is_async_filter()
+    {
+        var hits = await _queryService.Run(
+            new QueryRequest(_dbPath, "asynchronous method", 20, new QueryFilters("method", null, null, IsAsync: true)),
+            CancellationToken.None);
+
+        hits.Should().NotBeEmpty();
+        hits.Should().Contain(h => h.FullyQualifiedSymbolName.Contains("FindAsync", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary

Adds \`coderag query <text>\` — natural-language search over a \`.coderag/index.db\` produced by \`coderag index\`. Embeds the query with the same model the index used (\`text-embedding-3-large\`, 3072 dim), runs filtered KNN against \`chunk_embeddings\` joined with \`code_chunks\` metadata, returns top-K hits.

## CLI

\`\`\`
coderag query <text> [--db <path>] [--top-k 10]
                     [--kind <method|class|...>] [--project <name>]
                     [--namespace <ns>] [--is-async]
                     [--format text|json]
\`\`\`

## Architecture

- \`IQueryService\` (public) → \`QueryService\` (internal sealed): embed → \`IIndexStore.Search\`
- \`SqliteIndexStore.Search\` uses oversample-then-filter SQL (CTE pulls top 200 KNN candidates, outer query AND's filters, takes top-K)
- Vector binding reuses existing little-endian float32 blob path; sqlite-vec accepts the same blob in both \`INSERT\` and \`MATCH\`

## Real-world smoke test

Against the gtav-factions index (8,295 chunks): \`query \"create a new faction\" --kind method\` returns \`FactionInitializer.CreateFactions()\` as the top hit, followed by test helpers that build test factions. Semantic match works.

## Test plan

- [x] 3 new integration tests (basic ranking, kind filter, is_async filter) — pass
- [x] All 137 prior tests still pass — total 140/140
- [x] Pre-commit clean (build + format + 55 unit/architecture tests)
- [x] End-to-end smoke against a real index returns sensible ranked matches
- [ ] Squash-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)