### PR TITLE
feat(core): voyage embeddings, BM25 hybrid, expanded filters (#12)

### DIFF
--- a/src/CodeRag.Cli/Commands/IndexCommand.cs
+++ b/src/CodeRag.Cli/Commands/IndexCommand.cs
@@ -14,9 +14,9 @@ internal sealed class IndexCommand
 
     public async Task<int> ExecuteAsync(string solutionPath, string? outputDir, CancellationToken cancellationToken)
     {
-        if (Environment.GetEnvironmentVariable("OPENAI_API_KEY") is null)
+        if (!IsAnyEmbeddingKeyConfigured())
         {
-            await Console.Error.WriteLineAsync("OPENAI_API_KEY is not set.");
+            await Console.Error.WriteLineAsync("Neither VOYAGE_API_KEY nor OPENAI_API_KEY is set.");
             return 2;
         }
         if (!File.Exists(solutionPath))
@@ -36,5 +36,11 @@ internal sealed class IndexCommand
                           $"{result.EmbeddedChunks} embeddings.");
         Console.WriteLine($"Wrote: {dbPath}");
         return 0;
+    }
+
+    private static bool IsAnyEmbeddingKeyConfigured()
+    {
+        return Environment.GetEnvironmentVariable("VOYAGE_API_KEY") is not null
+            || Environment.GetEnvironmentVariable("OPENAI_API_KEY") is not null;
     }
 }

--- a/src/CodeRag.Cli/Commands/QueryCommand.cs
+++ b/src/CodeRag.Cli/Commands/QueryCommand.cs
@@ -16,35 +16,26 @@ internal sealed class QueryCommand
         _queryService = queryService;
     }
 
-    public async Task<int> ExecuteAsync(
-        string text,
-        string? dbPath,
-        int topK,
-        string? kind,
-        string? project,
-        string? containingNamespace,
-        bool? isAsync,
-        string format,
-        CancellationToken cancellationToken)
+    public async Task<int> ExecuteAsync(QueryCommandOptions options, CancellationToken cancellationToken)
     {
-        if (Environment.GetEnvironmentVariable("OPENAI_API_KEY") is null)
+        if (!IsAnyEmbeddingKeyConfigured())
         {
-            await Console.Error.WriteLineAsync("OPENAI_API_KEY is not set.");
+            await Console.Error.WriteLineAsync("Neither VOYAGE_API_KEY nor OPENAI_API_KEY is set.");
             return 2;
         }
 
-        var resolvedDb = dbPath ?? Path.Combine(Directory.GetCurrentDirectory(), ".coderag", "index.db");
+        var resolvedDb = options.DbPath ?? Path.Combine(Directory.GetCurrentDirectory(), ".coderag", "index.db");
         if (!File.Exists(resolvedDb))
         {
             await Console.Error.WriteLineAsync($"Index not found: {resolvedDb}");
             return 2;
         }
 
-        var filters = new QueryFilters(kind, project, containingNamespace, isAsync);
-        var request = new QueryRequest(resolvedDb, text, topK, filters);
+        var filters = BuildFilters(options);
+        var request = new QueryRequest(resolvedDb, options.Text, options.TopK, filters);
         var hits = await _queryService.Run(request, cancellationToken);
 
-        if (string.Equals(format, "json", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(options.Format, "json", StringComparison.OrdinalIgnoreCase))
         {
             WriteJson(hits);
         }
@@ -53,6 +44,28 @@ internal sealed class QueryCommand
             WriteText(hits);
         }
         return 0;
+    }
+
+    private static bool IsAnyEmbeddingKeyConfigured()
+    {
+        return Environment.GetEnvironmentVariable("VOYAGE_API_KEY") is not null
+            || Environment.GetEnvironmentVariable("OPENAI_API_KEY") is not null;
+    }
+
+    private static QueryFilters BuildFilters(QueryCommandOptions options)
+    {
+        return new QueryFilters(
+            SymbolKind: options.SymbolKind,
+            ContainingProjectName: options.Project,
+            ContainingNamespace: options.ContainingNamespace,
+            IsAsync: options.IsAsync,
+            Accessibility: options.Accessibility,
+            HasAttributeFullyQualifiedName: options.HasAttribute,
+            ImplementsInterfaceFullyQualifiedName: options.Implements,
+            ReturnTypeContains: options.ReturnTypeContains,
+            ExcludeTests: options.ExcludeTests,
+            ExcludeNamespaceContains: options.ExcludeNamespace,
+            MaxDistance: options.MaxDistance);
     }
 
     private static void WriteJson(IReadOnlyList<QueryHit> hits)
@@ -67,12 +80,13 @@ internal sealed class QueryCommand
         {
             var header = string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}:{1}-{2}  {3}  ({4}, dist={5:F4})",
+                "{0}:{1}-{2}  {3}  ({4}, score={5:F4}, dist={6:F4})",
                 hit.RelativeFilePath,
                 hit.LineStart,
                 hit.LineEnd,
                 hit.FullyQualifiedSymbolName,
                 hit.SymbolKind,
+                hit.FusedScore,
                 hit.Distance);
             Console.WriteLine(header);
             Console.WriteLine(hit.SourceText);

--- a/src/CodeRag.Cli/Commands/QueryCommandOptions.cs
+++ b/src/CodeRag.Cli/Commands/QueryCommandOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace CodeRag.Cli.Commands;
+
+internal sealed record QueryCommandOptions(
+    string Text,
+    string? DbPath,
+    int TopK,
+    string? SymbolKind,
+    string? Project,
+    string? ContainingNamespace,
+    bool? IsAsync,
+    string? Accessibility,
+    string? HasAttribute,
+    string? Implements,
+    string? ReturnTypeContains,
+    bool ExcludeTests,
+    string? ExcludeNamespace,
+    double? MaxDistance,
+    string Format);

--- a/src/CodeRag.Cli/Program.cs
+++ b/src/CodeRag.Cli/Program.cs
@@ -30,6 +30,13 @@ var kindOpt = new Option<string?>("--kind", "Filter by symbol_kind (e.g. method,
 var projectOpt = new Option<string?>("--project", "Filter by containing project name.");
 var nsOpt = new Option<string?>("--namespace", "Filter by containing namespace.");
 var asyncOpt = new Option<bool?>("--is-async", "Filter to async methods only.");
+var accessibilityOpt = new Option<string?>("--accessibility", "Filter by accessibility (public, internal, protected, ...).");
+var hasAttrOpt = new Option<string?>("--has-attribute", "Filter chunks that carry the given attribute (fully qualified).");
+var implementsOpt = new Option<string?>("--implements", "Filter chunks implementing the given interface (fully qualified).");
+var returnTypeContainsOpt = new Option<string?>("--return-type-contains", "Filter chunks whose return type contains the given substring.");
+var excludeTestsOpt = new Option<bool>("--exclude-tests", () => false, "Exclude chunks in test namespaces.");
+var excludeNsOpt = new Option<string?>("--exclude-namespace", "Exclude chunks whose namespace contains the given substring.");
+var maxDistanceOpt = new Option<double?>("--max-distance", "Drop hits with KNN distance above this value.");
 var formatOpt = new Option<string>("--format", () => "text", "Output format: text or json.");
 
 var queryCmd = new Command("query", "Search the code index for chunks similar to a natural-language query.");
@@ -40,19 +47,34 @@ queryCmd.AddOption(kindOpt);
 queryCmd.AddOption(projectOpt);
 queryCmd.AddOption(nsOpt);
 queryCmd.AddOption(asyncOpt);
+queryCmd.AddOption(accessibilityOpt);
+queryCmd.AddOption(hasAttrOpt);
+queryCmd.AddOption(implementsOpt);
+queryCmd.AddOption(returnTypeContainsOpt);
+queryCmd.AddOption(excludeTestsOpt);
+queryCmd.AddOption(excludeNsOpt);
+queryCmd.AddOption(maxDistanceOpt);
 queryCmd.AddOption(formatOpt);
 queryCmd.SetHandler(async (InvocationContext ctx) =>
 {
-    var text = ctx.ParseResult.GetValueForArgument(textArg);
-    var db = ctx.ParseResult.GetValueForOption(dbOpt);
-    var topK = ctx.ParseResult.GetValueForOption(topKOpt);
-    var kind = ctx.ParseResult.GetValueForOption(kindOpt);
-    var project = ctx.ParseResult.GetValueForOption(projectOpt);
-    var ns = ctx.ParseResult.GetValueForOption(nsOpt);
-    var isAsync = ctx.ParseResult.GetValueForOption(asyncOpt);
-    var format = ctx.ParseResult.GetValueForOption(formatOpt) ?? "text";
+    var options = new QueryCommandOptions(
+        Text: ctx.ParseResult.GetValueForArgument(textArg),
+        DbPath: ctx.ParseResult.GetValueForOption(dbOpt)?.FullName,
+        TopK: ctx.ParseResult.GetValueForOption(topKOpt),
+        SymbolKind: ctx.ParseResult.GetValueForOption(kindOpt),
+        Project: ctx.ParseResult.GetValueForOption(projectOpt),
+        ContainingNamespace: ctx.ParseResult.GetValueForOption(nsOpt),
+        IsAsync: ctx.ParseResult.GetValueForOption(asyncOpt),
+        Accessibility: ctx.ParseResult.GetValueForOption(accessibilityOpt),
+        HasAttribute: ctx.ParseResult.GetValueForOption(hasAttrOpt),
+        Implements: ctx.ParseResult.GetValueForOption(implementsOpt),
+        ReturnTypeContains: ctx.ParseResult.GetValueForOption(returnTypeContainsOpt),
+        ExcludeTests: ctx.ParseResult.GetValueForOption(excludeTestsOpt),
+        ExcludeNamespace: ctx.ParseResult.GetValueForOption(excludeNsOpt),
+        MaxDistance: ctx.ParseResult.GetValueForOption(maxDistanceOpt),
+        Format: ctx.ParseResult.GetValueForOption(formatOpt) ?? "text");
     var command = host.Services.GetRequiredService<QueryCommand>();
-    ctx.ExitCode = await command.ExecuteAsync(text, db?.FullName, topK, kind, project, ns, isAsync, format, ctx.GetCancellationToken());
+    ctx.ExitCode = await command.ExecuteAsync(options, ctx.GetCancellationToken());
 });
 
 var rootCommand = new RootCommand("CodeRag — code RAG indexer");

--- a/src/CodeRag.Core/Indexing/ChunkExtractor.cs
+++ b/src/CodeRag.Core/Indexing/ChunkExtractor.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Text.Json;
+using System.Xml;
+using System.Xml.Linq;
 using CodeRag.Core.Indexing.Interfaces;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -214,6 +216,7 @@ public sealed class ChunkExtractor : IChunkExtractor
             ReturnTypeFullyQualifiedName: null,
             ParameterCount: null,
             DocumentationCommentXml: NullIfEmpty(symbol.GetDocumentationCommentXml()),
+            XmlDocSummary: ResolveXmlDocSummary(symbol),
             SourceText: sourceText,
             SourceTextHash: _hashingService.Hash(sourceText),
             Attributes: BuildAttributes(symbol),
@@ -476,6 +479,7 @@ public sealed class ChunkExtractor : IChunkExtractor
             ReturnTypeFullyQualifiedName: details.ReturnType,
             ParameterCount: details.ParameterCount,
             DocumentationCommentXml: NullIfEmpty(symbol.GetDocumentationCommentXml()),
+            XmlDocSummary: ResolveXmlDocSummary(symbol),
             SourceText: sourceText,
             SourceTextHash: _hashingService.Hash(sourceText),
             Attributes: BuildAttributes(symbol),
@@ -585,6 +589,25 @@ public sealed class ChunkExtractor : IChunkExtractor
             return null;
         }
         return symbol.ContainingNamespace.ToDisplayString();
+    }
+
+    private static string? ResolveXmlDocSummary(ISymbol symbol)
+    {
+        var xml = symbol.GetDocumentationCommentXml();
+        if (string.IsNullOrWhiteSpace(xml))
+        {
+            return null;
+        }
+        try
+        {
+            var document = XDocument.Parse(xml);
+            var summary = document.Descendants("summary").FirstOrDefault()?.Value?.Trim();
+            return string.IsNullOrEmpty(summary) ? null : summary;
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
     }
 
     private sealed record ChunkLocation(string RelativeFilePath, int StartLineNumber, int EndLineNumber);

--- a/src/CodeRag.Core/Indexing/CodeChunk.cs
+++ b/src/CodeRag.Core/Indexing/CodeChunk.cs
@@ -20,6 +20,7 @@ public sealed record CodeChunk(
     string? ReturnTypeFullyQualifiedName,
     int? ParameterCount,
     string? DocumentationCommentXml,
+    string? XmlDocSummary,
     string SourceText,
     string SourceTextHash,
     ImmutableArray<ChunkAttribute> Attributes,

--- a/src/CodeRag.Core/Indexing/EmbeddingInputType.cs
+++ b/src/CodeRag.Core/Indexing/EmbeddingInputType.cs
@@ -1,0 +1,7 @@
+﻿namespace CodeRag.Core.Indexing;
+
+public enum EmbeddingInputType
+{
+    Document,
+    Query,
+}

--- a/src/CodeRag.Core/Indexing/EmbeddingTextBuilder.cs
+++ b/src/CodeRag.Core/Indexing/EmbeddingTextBuilder.cs
@@ -1,0 +1,28 @@
+﻿using System.Text;
+
+namespace CodeRag.Core.Indexing;
+
+internal static class EmbeddingTextBuilder
+{
+    public static string BuildEmbeddingInput(CodeChunk chunk)
+    {
+        var sb = new StringBuilder();
+        sb.Append("FQN: ").AppendLine(chunk.FullyQualifiedSymbolName);
+        sb.Append("Kind: ").AppendLine(chunk.SymbolKind);
+        if (!string.IsNullOrEmpty(chunk.ParentSymbolFullyQualifiedName))
+        {
+            sb.Append("Parent: ").AppendLine(chunk.ParentSymbolFullyQualifiedName);
+        }
+        if (!string.IsNullOrEmpty(chunk.SymbolSignatureDisplay))
+        {
+            sb.Append("Signature: ").AppendLine(chunk.SymbolSignatureDisplay);
+        }
+        if (!string.IsNullOrEmpty(chunk.XmlDocSummary))
+        {
+            sb.Append("Summary: ").AppendLine(chunk.XmlDocSummary);
+        }
+        sb.AppendLine();
+        sb.Append(chunk.SourceText);
+        return sb.ToString();
+    }
+}

--- a/src/CodeRag.Core/Indexing/IIndexStore.cs
+++ b/src/CodeRag.Core/Indexing/IIndexStore.cs
@@ -13,6 +13,7 @@ internal interface IIndexStore : IDisposable
     Task<long> InsertChunkAsync(CodeChunk chunk, CancellationToken cancellationToken);
     Task UpdateChunkAsync(long chunkId, CodeChunk chunk, CancellationToken cancellationToken);
     Task UpsertEmbeddingAsync(long chunkId, ReadOnlyMemory<float> embedding, CancellationToken cancellationToken);
+    Task UpsertFtsContentAsync(long chunkId, string content, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<StoredChunkSummary>> GetChunkSummariesForFileAsync(string relativeFilePath, CancellationToken cancellationToken);
     Task DeleteChunkAsync(long chunkId, CancellationToken cancellationToken);
@@ -20,6 +21,7 @@ internal interface IIndexStore : IDisposable
 
     Task<IReadOnlyList<QueryHit>> Search(
         ReadOnlyMemory<float> queryVector,
+        string queryText,
         QueryFilters filters,
         int topK,
         CancellationToken cancellationToken);

--- a/src/CodeRag.Core/Indexing/IndexingService.cs
+++ b/src/CodeRag.Core/Indexing/IndexingService.cs
@@ -107,7 +107,7 @@ internal sealed class IndexingService : IIndexingService
         foreach (var op in inserts)
         {
             var id = await store.InsertChunkAsync(op.Chunk, cancellationToken);
-            queue.Add(new EmbedQueueItem(id, op.Chunk.SourceText));
+            queue.Add(BuildQueueItem(id, op.Chunk));
             count++;
         }
         return new InsertApplyResult(count, queue);
@@ -122,11 +122,17 @@ internal sealed class IndexingService : IIndexingService
             await store.UpdateChunkAsync(op.ChunkId, op.Chunk, cancellationToken);
             if (op.ContentChanged)
             {
-                queue.Add(new EmbedQueueItem(op.ChunkId, op.Chunk.SourceText));
+                queue.Add(BuildQueueItem(op.ChunkId, op.Chunk));
             }
             count++;
         }
         return new UpdateApplyResult(count, queue);
+    }
+
+    private static EmbedQueueItem BuildQueueItem(long chunkId, CodeChunk chunk)
+    {
+        var enriched = EmbeddingTextBuilder.BuildEmbeddingInput(chunk);
+        return new EmbedQueueItem(chunkId, enriched);
     }
 
     private async Task<int> EmbedAndUpsert(IIndexStore store, IReadOnlyList<EmbedQueueItem> embedQueue, CancellationToken cancellationToken)
@@ -135,11 +141,13 @@ internal sealed class IndexingService : IIndexingService
         {
             return 0;
         }
-        var inputs = embedQueue.Select(q => q.SourceText).ToList();
-        var vectors = await _deps.EmbeddingClient.Embed(inputs, cancellationToken);
+        var inputs = embedQueue.Select(q => q.EmbeddingInput).ToList();
+        var vectors = await _deps.EmbeddingClient.Embed(inputs, EmbeddingInputType.Document, cancellationToken);
         for (int i = 0; i < embedQueue.Count; i++)
         {
-            await store.UpsertEmbeddingAsync(embedQueue[i].ChunkId, vectors[i], cancellationToken);
+            var item = embedQueue[i];
+            await store.UpsertEmbeddingAsync(item.ChunkId, vectors[i], cancellationToken);
+            await store.UpsertFtsContentAsync(item.ChunkId, item.EmbeddingInput, cancellationToken);
         }
         return embedQueue.Count;
     }
@@ -147,13 +155,27 @@ internal sealed class IndexingService : IIndexingService
     private IndexMetadata BuildMetadata(IndexRunRequest request, string repoRoot, string headSha)
     {
         return new IndexMetadata(
-            SchemaVersion: 1,
+            SchemaVersion: 2,
             SolutionFilePath: request.SolutionFilePath,
             RepositoryRootPath: repoRoot,
             IndexedAtCommitSha: headSha,
             IndexedAtUtc: _deps.Time.GetUtcNow(),
-            EmbeddingModelName: EmbeddingOptions.ModelName,
-            EmbeddingVectorDimensions: EmbeddingOptions.VectorDimensions);
+            EmbeddingModelName: ResolveEmbeddingModelName(),
+            EmbeddingVectorDimensions: _deps.EmbeddingClient.VectorDimensions);
+    }
+
+    private string ResolveEmbeddingModelName()
+    {
+        var dim = _deps.EmbeddingClient.VectorDimensions;
+        if (dim == VoyageEmbeddingOptions.VectorDimensions)
+        {
+            return VoyageEmbeddingOptions.ModelName;
+        }
+        if (dim == OpenAIEmbeddingOptions.VectorDimensions)
+        {
+            return OpenAIEmbeddingOptions.ModelName;
+        }
+        return _deps.EmbeddingClient.GetType().Name;
     }
 
     private async Task<ReconciliationPlan> PlanFullReindex(
@@ -313,7 +335,7 @@ internal sealed class IndexingService : IIndexingService
 
     private sealed record RunCounts(int Inserted, int Updated, int Deleted, int Embedded);
 
-    private sealed record EmbedQueueItem(long ChunkId, string SourceText);
+    private sealed record EmbedQueueItem(long ChunkId, string EmbeddingInput);
 
     private sealed record InsertApplyResult(int InsertedCount, IReadOnlyList<EmbedQueueItem> EmbedQueue);
 

--- a/src/CodeRag.Core/Indexing/Interfaces/IEmbeddingClient.cs
+++ b/src/CodeRag.Core/Indexing/Interfaces/IEmbeddingClient.cs
@@ -2,5 +2,6 @@
 
 public interface IEmbeddingClient
 {
-    Task<IReadOnlyList<ReadOnlyMemory<float>>> Embed(IReadOnlyList<string> inputs, CancellationToken cancellationToken);
+    int VectorDimensions { get; }
+    Task<IReadOnlyList<ReadOnlyMemory<float>>> Embed(IReadOnlyList<string> inputs, EmbeddingInputType inputType, CancellationToken cancellationToken);
 }

--- a/src/CodeRag.Core/Indexing/OpenAIEmbeddingClient.cs
+++ b/src/CodeRag.Core/Indexing/OpenAIEmbeddingClient.cs
@@ -10,16 +10,19 @@ public sealed class OpenAIEmbeddingClient : IEmbeddingClient
 
     public OpenAIEmbeddingClient(string apiKey)
     {
-        _client = new EmbeddingClient(model: EmbeddingOptions.ModelName, apiKey: apiKey);
+        _client = new EmbeddingClient(model: OpenAIEmbeddingOptions.ModelName, apiKey: apiKey);
     }
 
-    public async Task<IReadOnlyList<ReadOnlyMemory<float>>> Embed(IReadOnlyList<string> inputs, CancellationToken cancellationToken)
+    public int VectorDimensions => OpenAIEmbeddingOptions.VectorDimensions;
+
+    public async Task<IReadOnlyList<ReadOnlyMemory<float>>> Embed(IReadOnlyList<string> inputs, EmbeddingInputType inputType, CancellationToken cancellationToken)
     {
+        _ = inputType;
         var results = new ReadOnlyMemory<float>[inputs.Count];
-        for (int batchStart = 0; batchStart < inputs.Count; batchStart += EmbeddingOptions.MaxBatchSize)
+        for (int batchStart = 0; batchStart < inputs.Count; batchStart += OpenAIEmbeddingOptions.MaxBatchSize)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            int batchEnd = Math.Min(batchStart + EmbeddingOptions.MaxBatchSize, inputs.Count);
+            int batchEnd = Math.Min(batchStart + OpenAIEmbeddingOptions.MaxBatchSize, inputs.Count);
             var batchInputs = inputs.Skip(batchStart).Take(batchEnd - batchStart).Select(TruncateForModel).ToList();
             var batchVectors = await EmbedBatchWithRetry(batchInputs, cancellationToken);
             for (int i = 0; i < batchVectors.Count; i++)
@@ -34,7 +37,7 @@ public sealed class OpenAIEmbeddingClient : IEmbeddingClient
     private async Task<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchWithRetry(IReadOnlyList<string> inputs, CancellationToken cancellationToken)
     {
         Exception? lastError = null;
-        for (int attempt = 0; attempt < EmbeddingOptions.MaxRetryAttempts; attempt++)
+        for (int attempt = 0; attempt < OpenAIEmbeddingOptions.MaxRetryAttempts; attempt++)
         {
             try
             {
@@ -48,7 +51,7 @@ public sealed class OpenAIEmbeddingClient : IEmbeddingClient
                 await Task.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken);
             }
         }
-        throw new InvalidOperationException($"OpenAI embed failed after {EmbeddingOptions.MaxRetryAttempts} attempts.", lastError);
+        throw new InvalidOperationException($"OpenAI embed failed after {OpenAIEmbeddingOptions.MaxRetryAttempts} attempts.", lastError);
     }
 
     private static bool IsRetriable(Exception ex)

--- a/src/CodeRag.Core/Indexing/OpenAIEmbeddingOptions.cs
+++ b/src/CodeRag.Core/Indexing/OpenAIEmbeddingOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace CodeRag.Core.Indexing;
 
-public sealed record EmbeddingOptions
+public sealed record OpenAIEmbeddingOptions
 {
     public const string ModelName = "text-embedding-3-large";
     public const int VectorDimensions = 3072;

--- a/src/CodeRag.Core/Indexing/QueryFilters.cs
+++ b/src/CodeRag.Core/Indexing/QueryFilters.cs
@@ -4,4 +4,11 @@ public sealed record QueryFilters(
     string? SymbolKind,
     string? ContainingProjectName,
     string? ContainingNamespace,
-    bool? IsAsync);
+    bool? IsAsync,
+    string? Accessibility,
+    string? HasAttributeFullyQualifiedName,
+    string? ImplementsInterfaceFullyQualifiedName,
+    string? ReturnTypeContains,
+    bool ExcludeTests,
+    string? ExcludeNamespaceContains,
+    double? MaxDistance);

--- a/src/CodeRag.Core/Indexing/QueryHit.cs
+++ b/src/CodeRag.Core/Indexing/QueryHit.cs
@@ -8,4 +8,5 @@ public sealed record QueryHit(
     string FullyQualifiedSymbolName,
     string SymbolKind,
     double Distance,
+    double FusedScore,
     string SourceText);

--- a/src/CodeRag.Core/Indexing/QueryService.cs
+++ b/src/CodeRag.Core/Indexing/QueryService.cs
@@ -16,11 +16,11 @@ internal sealed class QueryService : IQueryService
     public async Task<IReadOnlyList<QueryHit>> Run(QueryRequest request, CancellationToken cancellationToken)
     {
         var inputs = new[] { request.Text };
-        var vectors = await _embeddingClient.Embed(inputs, cancellationToken);
+        var vectors = await _embeddingClient.Embed(inputs, EmbeddingInputType.Query, cancellationToken);
         var queryVector = vectors[0];
 
         using var store = _storeFactory(request.IndexDatabasePath);
         await store.OpenAsync(cancellationToken);
-        return await store.Search(queryVector, request.Filters, request.TopK, cancellationToken);
+        return await store.Search(queryVector, request.Text, request.Filters, request.TopK, cancellationToken);
     }
 }

--- a/src/CodeRag.Core/Indexing/Sql/Schema.v2.sql
+++ b/src/CodeRag.Core/Indexing/Sql/Schema.v2.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS code_chunks (
     parameter_count                       INTEGER NULL,
 
     documentation_comment_xml             TEXT NULL,
+    xml_doc_summary                       TEXT NULL,
 
     source_text                           TEXT NOT NULL,
     source_text_hash                      TEXT NOT NULL
@@ -94,4 +95,6 @@ CREATE INDEX IF NOT EXISTS idx_attributes_name      ON chunk_attributes(attribut
 CREATE INDEX IF NOT EXISTS idx_interfaces_name      ON chunk_implemented_interfaces(interface_fully_qualified_name);
 CREATE INDEX IF NOT EXISTS idx_params_type          ON chunk_method_parameters(parameter_type_fully_qualified_name);
 
-CREATE VIRTUAL TABLE IF NOT EXISTS chunk_embeddings USING vec0(embedding float[3072]);
+CREATE VIRTUAL TABLE IF NOT EXISTS chunk_embeddings USING vec0(embedding float[{EMBEDDING_DIM}]);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS chunk_text_index USING fts5(chunk_id UNINDEXED, content);

--- a/src/CodeRag.Core/Indexing/SqliteIndexStore.cs
+++ b/src/CodeRag.Core/Indexing/SqliteIndexStore.cs
@@ -1,20 +1,27 @@
 ﻿using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text;
 using Microsoft.Data.Sqlite;
 
 namespace CodeRag.Core.Indexing;
 
 internal sealed class SqliteIndexStore : IIndexStore
 {
-    private const int CurrentSchemaVersion = 1;
+    private const int CurrentSchemaVersion = 2;
+    private const double RrfK = 60.0;
+    private const int OversampleFloor = 200;
+    private const int Bm25Limit = 200;
+
     private readonly string _databasePath;
+    private readonly int _embeddingVectorDimensions;
     private SqliteConnection? _connection;
     private SqliteTransaction? _transaction;
 
-    public SqliteIndexStore(string databasePath)
+    public SqliteIndexStore(string databasePath, int embeddingVectorDimensions)
     {
         _databasePath = databasePath;
+        _embeddingVectorDimensions = embeddingVectorDimensions;
     }
 
     internal SqliteConnection Connection => _connection
@@ -133,11 +140,11 @@ internal sealed class SqliteIndexStore : IIndexStore
              is_static, is_abstract, is_sealed, is_virtual, is_override, is_async,
              is_partial, is_readonly, is_extern, is_unsafe, is_extension_method, is_generic,
              base_type_fully_qualified_name, return_type_fully_qualified_name, parameter_count,
-             documentation_comment_xml, source_text, source_text_hash)
+             documentation_comment_xml, xml_doc_summary, source_text, source_text_hash)
             VALUES ($proj, $asm, $path, $sline, $eline,
                     $kind, $disp, $sig, $fqn, $ns, $parent,
                     $acc, $st, $ab, $sl, $vi, $ov, $as, $pa, $rd, $ex, $un, $em, $ge,
-                    $base, $ret, $pc, $doc, $src, $hash)
+                    $base, $ret, $pc, $doc, $xsum, $src, $hash)
             RETURNING chunk_id";
         await using var cmd = Connection.CreateCommand();
         cmd.Transaction = _transaction;
@@ -163,7 +170,8 @@ internal sealed class SqliteIndexStore : IIndexStore
             is_extern = $ex, is_unsafe = $un, is_extension_method = $em, is_generic = $ge,
             base_type_fully_qualified_name = $base,
             return_type_fully_qualified_name = $ret, parameter_count = $pc,
-            documentation_comment_xml = $doc, source_text = $src, source_text_hash = $hash
+            documentation_comment_xml = $doc, xml_doc_summary = $xsum,
+            source_text = $src, source_text_hash = $hash
             WHERE chunk_id = $id";
         await using var cmd = Connection.CreateCommand();
         cmd.Transaction = _transaction;
@@ -196,6 +204,18 @@ internal sealed class SqliteIndexStore : IIndexStore
         await ins.ExecuteNonQueryAsync(cancellationToken);
     }
 
+    async Task IIndexStore.UpsertFtsContentAsync(long chunkId, string content, CancellationToken cancellationToken)
+    {
+        await DeleteFtsRowAsync(chunkId, cancellationToken);
+        const string insertSql = "INSERT INTO chunk_text_index(chunk_id, content) VALUES ($id, $content)";
+        await using var ins = Connection.CreateCommand();
+        ins.Transaction = _transaction;
+        ins.CommandText = insertSql;
+        ins.Parameters.AddWithValue("$id", chunkId);
+        ins.Parameters.AddWithValue("$content", content);
+        await ins.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     async Task<IReadOnlyList<StoredChunkSummary>> IIndexStore.GetChunkSummariesForFileAsync(string relativeFilePath, CancellationToken cancellationToken)
     {
         const string sql = @"SELECT chunk_id, fully_qualified_symbol_name, source_text_hash
@@ -216,6 +236,7 @@ internal sealed class SqliteIndexStore : IIndexStore
     async Task IIndexStore.DeleteChunkAsync(long chunkId, CancellationToken cancellationToken)
     {
         await DeleteEmbeddingRowAsync(chunkId, cancellationToken);
+        await DeleteFtsRowAsync(chunkId, cancellationToken);
         await DeleteChildRowsAsync(chunkId, cancellationToken);
         await DeleteChunkRowAsync(chunkId, cancellationToken);
     }
@@ -239,6 +260,15 @@ internal sealed class SqliteIndexStore : IIndexStore
         await cmd.ExecuteNonQueryAsync(cancellationToken);
     }
 
+    private async Task DeleteFtsRowAsync(long chunkId, CancellationToken cancellationToken)
+    {
+        await using var cmd = Connection.CreateCommand();
+        cmd.Transaction = _transaction;
+        cmd.CommandText = "DELETE FROM chunk_text_index WHERE chunk_id = $id";
+        cmd.Parameters.AddWithValue("$id", chunkId);
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
+    }
+
     private async Task DeleteChunkRowAsync(long chunkId, CancellationToken cancellationToken)
     {
         await using var cmd = Connection.CreateCommand();
@@ -256,7 +286,7 @@ internal sealed class SqliteIndexStore : IIndexStore
             accessibility, is_static, is_abstract, is_sealed, is_virtual, is_override, is_async,
             is_partial, is_readonly, is_extern, is_unsafe, is_extension_method, is_generic,
             base_type_fully_qualified_name, return_type_fully_qualified_name, parameter_count,
-            documentation_comment_xml, source_text, source_text_hash
+            documentation_comment_xml, xml_doc_summary, source_text, source_text_hash
             FROM code_chunks WHERE chunk_id = $id";
         await using var cmd = Connection.CreateCommand();
         cmd.Transaction = _transaction;
@@ -271,14 +301,14 @@ internal sealed class SqliteIndexStore : IIndexStore
         return await ProjectChunkAsync(chunkId, reader, cancellationToken);
     }
 
-    private async Task<CodeChunk> ProjectChunkAsync(long chunkId, Microsoft.Data.Sqlite.SqliteDataReader reader, CancellationToken cancellationToken)
+    private async Task<CodeChunk> ProjectChunkAsync(long chunkId, SqliteDataReader reader, CancellationToken cancellationToken)
     {
         var modifiers = ReadModifiersFromReader(reader);
         var children = await ReadChildCollectionsAsync(chunkId, cancellationToken);
         return await BuildChunkAsync(reader, modifiers, children, cancellationToken);
     }
 
-    private static ChunkModifiers ReadModifiersFromReader(Microsoft.Data.Sqlite.SqliteDataReader reader)
+    private static ChunkModifiers ReadModifiersFromReader(SqliteDataReader reader)
     {
         return new ChunkModifiers(
             IsStatic: reader.GetInt64(12) != 0,
@@ -317,7 +347,7 @@ internal sealed class SqliteIndexStore : IIndexStore
     }
 
     private static async Task<CodeChunk> BuildChunkAsync(
-        Microsoft.Data.Sqlite.SqliteDataReader reader,
+        SqliteDataReader reader,
         ChunkModifiers modifiers,
         ChunkChildCollections children,
         CancellationToken cancellationToken)
@@ -340,8 +370,9 @@ internal sealed class SqliteIndexStore : IIndexStore
             ReturnTypeFullyQualifiedName: await reader.IsDBNullAsync(25, cancellationToken) ? null : reader.GetString(25),
             ParameterCount: await reader.IsDBNullAsync(26, cancellationToken) ? null : reader.GetInt32(26),
             DocumentationCommentXml: await reader.IsDBNullAsync(27, cancellationToken) ? null : reader.GetString(27),
-            SourceText: reader.GetString(28),
-            SourceTextHash: reader.GetString(29),
+            XmlDocSummary: await reader.IsDBNullAsync(28, cancellationToken) ? null : reader.GetString(28),
+            SourceText: reader.GetString(29),
+            SourceTextHash: reader.GetString(30),
             Attributes: children.Attributes.ToImmutableArray(),
             ImplementedInterfaceFullyQualifiedNames: children.Interfaces.ToImmutableArray(),
             Parameters: children.Parameters.ToImmutableArray(),
@@ -384,14 +415,18 @@ internal sealed class SqliteIndexStore : IIndexStore
         var existing = await TryGetSchemaVersionAsync(cancellationToken);
         if (existing is null)
         {
-            await ApplySchemaAsync("Schema.v1.sql", cancellationToken);
+            await ApplySchemaAsync("Schema.v2.sql", cancellationToken);
             return;
         }
         if (existing.Value != CurrentSchemaVersion)
         {
             throw new InvalidOperationException(
-                $"index_metadata.schema version {existing.Value} does not match expected version {CurrentSchemaVersion}. " +
-                "Delete the index file and re-run; v1 has no online migration.");
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Index at {0} uses schema version {1}. This build expects schema version {2}. Delete the file and re-run `coderag index ...` to migrate.",
+                    _databasePath,
+                    existing.Value,
+                    CurrentSchemaVersion));
         }
     }
 
@@ -423,6 +458,7 @@ internal sealed class SqliteIndexStore : IIndexStore
             ?? throw new InvalidOperationException($"Embedded SQL resource not found: {fullName}");
         using var reader = new StreamReader(stream);
         var sql = await reader.ReadToEndAsync(cancellationToken);
+        sql = sql.Replace("{EMBEDDING_DIM}", _embeddingVectorDimensions.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
         await using var cmd = Connection.CreateCommand();
         cmd.CommandText = sql;
         await cmd.ExecuteNonQueryAsync(cancellationToken);
@@ -469,6 +505,7 @@ internal sealed class SqliteIndexStore : IIndexStore
         cmd.Parameters.AddWithValue("$ret", (object?)c.ReturnTypeFullyQualifiedName ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$pc", c.ParameterCount.HasValue ? c.ParameterCount.Value : DBNull.Value);
         cmd.Parameters.AddWithValue("$doc", (object?)c.DocumentationCommentXml ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$xsum", (object?)c.XmlDocSummary ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$src", c.SourceText);
         cmd.Parameters.AddWithValue("$hash", c.SourceTextHash);
     }
@@ -569,7 +606,7 @@ internal sealed class SqliteIndexStore : IIndexStore
         "Security",
         "CA2100:Review SQL queries for security vulnerabilities",
         Justification = "SQL is provided by internal callers; no user input flows in.")]
-    private async Task<List<T>> ReadChildAsync<T>(long chunkId, string sql, Func<Microsoft.Data.Sqlite.SqliteDataReader, T> map, CancellationToken cancellationToken)
+    private async Task<List<T>> ReadChildAsync<T>(long chunkId, string sql, Func<SqliteDataReader, T> map, CancellationToken cancellationToken)
     {
         await using var cmd = Connection.CreateCommand();
         cmd.Transaction = _transaction;
@@ -579,81 +616,218 @@ internal sealed class SqliteIndexStore : IIndexStore
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
-            list.Add(map((Microsoft.Data.Sqlite.SqliteDataReader)reader));
+            list.Add(map((SqliteDataReader)reader));
         }
         return list;
     }
 
     public async Task<IReadOnlyList<QueryHit>> Search(
         ReadOnlyMemory<float> queryVector,
+        string queryText,
         QueryFilters filters,
         int topK,
         CancellationToken cancellationToken)
     {
-        var oversample = Math.Max(topK * 20, 200);
+        int oversample = Math.Max(topK * 20, OversampleFloor);
+        var knn = await RunKnnAsync(queryVector, oversample, cancellationToken);
+        var bm25 = await RunBm25Async(queryText, cancellationToken);
+        var fused = FuseResults(knn, bm25);
+        return await ProjectFusedHitsAsync(fused, filters, topK, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<KnnRanked>> RunKnnAsync(ReadOnlyMemory<float> queryVector, int oversample, CancellationToken cancellationToken)
+    {
+        const string sql = @"SELECT rowid, distance
+            FROM chunk_embeddings
+            WHERE embedding MATCH $query_vector
+            ORDER BY distance
+            LIMIT $oversample";
         await using var cmd = Connection.CreateCommand();
         cmd.Transaction = _transaction;
-        cmd.CommandText = SearchSql;
-        BindSearchParameters(cmd, queryVector, filters, topK, oversample);
-        return await ReadSearchResults(cmd, cancellationToken);
-    }
-
-    private static void BindSearchParameters(
-        SqliteCommand cmd,
-        ReadOnlyMemory<float> queryVector,
-        QueryFilters filters,
-        int topK,
-        int oversample)
-    {
+        cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("$query_vector", FloatArrayToBlob(queryVector.Span));
         cmd.Parameters.AddWithValue("$oversample", oversample);
-        cmd.Parameters.AddWithValue("$top_k", topK);
-        cmd.Parameters.AddWithValue("$symbol_kind", (object?)filters.SymbolKind ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$project", (object?)filters.ContainingProjectName ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$namespace", (object?)filters.ContainingNamespace ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$is_async", filters.IsAsync.HasValue ? (filters.IsAsync.Value ? 1 : 0) : DBNull.Value);
-    }
-
-    private static async Task<IReadOnlyList<QueryHit>> ReadSearchResults(SqliteCommand cmd, CancellationToken cancellationToken)
-    {
-        var results = new List<QueryHit>();
+        var results = new List<KnnRanked>();
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        int rank = 0;
         while (await reader.ReadAsync(cancellationToken))
         {
-            results.Add(new QueryHit(
-                ChunkId: reader.GetInt64(0),
-                RelativeFilePath: reader.GetString(1),
-                LineStart: reader.GetInt32(2),
-                LineEnd: reader.GetInt32(3),
-                FullyQualifiedSymbolName: reader.GetString(4),
-                SymbolKind: reader.GetString(5),
-                Distance: reader.GetDouble(6),
-                SourceText: reader.GetString(7)));
+            results.Add(new KnnRanked(reader.GetInt64(0), reader.GetDouble(1), rank));
+            rank++;
         }
         return results;
     }
 
-    private const string SearchSql = @"WITH candidates AS (
-    SELECT rowid, distance
-    FROM chunk_embeddings
-    WHERE embedding MATCH $query_vector
-    ORDER BY distance
-    LIMIT $oversample
-)
-SELECT c.chunk_id,
-       c.relative_file_path,
-       c.start_line_number,
-       c.end_line_number,
-       c.fully_qualified_symbol_name,
-       c.symbol_kind,
-       cand.distance,
-       c.source_text
-FROM candidates cand
-JOIN code_chunks c ON c.chunk_id = cand.rowid
-WHERE ($symbol_kind IS NULL OR c.symbol_kind = $symbol_kind)
+    private async Task<IReadOnlyList<Bm25Ranked>> RunBm25Async(string queryText, CancellationToken cancellationToken)
+    {
+        var sanitized = SanitizeBm25Query(queryText);
+        if (string.IsNullOrEmpty(sanitized))
+        {
+            return Array.Empty<Bm25Ranked>();
+        }
+        const string sql = @"SELECT chunk_id FROM chunk_text_index
+            WHERE chunk_text_index MATCH $bm25_query
+            ORDER BY rank LIMIT $bm25_limit";
+        await using var cmd = Connection.CreateCommand();
+        cmd.Transaction = _transaction;
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("$bm25_query", sanitized);
+        cmd.Parameters.AddWithValue("$bm25_limit", Bm25Limit);
+        var results = new List<Bm25Ranked>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        int rank = 0;
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var raw = reader.GetValue(0);
+            long id = Convert.ToInt64(raw, CultureInfo.InvariantCulture);
+            results.Add(new Bm25Ranked(id, rank));
+            rank++;
+        }
+        return results;
+    }
+
+    private static string SanitizeBm25Query(string queryText)
+    {
+        var sb = new StringBuilder(queryText.Length);
+        bool lastWasSpace = true;
+        foreach (var c in queryText)
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                sb.Append(c);
+                lastWasSpace = false;
+            }
+            else if (char.IsWhiteSpace(c))
+            {
+                if (!lastWasSpace)
+                {
+                    sb.Append(' ');
+                    lastWasSpace = true;
+                }
+            }
+        }
+        return sb.ToString().Trim();
+    }
+
+    private static IReadOnlyDictionary<long, FusedCandidate> FuseResults(
+        IReadOnlyList<KnnRanked> knn,
+        IReadOnlyList<Bm25Ranked> bm25)
+    {
+        var fused = new Dictionary<long, FusedCandidate>();
+        foreach (var k in knn)
+        {
+            var contribution = 1.0 / (RrfK + k.Rank);
+            fused[k.ChunkId] = new FusedCandidate(k.ChunkId, k.Distance, contribution);
+        }
+        foreach (var b in bm25)
+        {
+            var contribution = 1.0 / (RrfK + b.Rank);
+            if (fused.TryGetValue(b.ChunkId, out var existing))
+            {
+                fused[b.ChunkId] = existing with { Score = existing.Score + contribution };
+            }
+            else
+            {
+                fused[b.ChunkId] = new FusedCandidate(b.ChunkId, double.NaN, contribution);
+            }
+        }
+        return fused;
+    }
+
+    private async Task<IReadOnlyList<QueryHit>> ProjectFusedHitsAsync(
+        IReadOnlyDictionary<long, FusedCandidate> fused,
+        QueryFilters filters,
+        int topK,
+        CancellationToken cancellationToken)
+    {
+        if (fused.Count == 0)
+        {
+            return Array.Empty<QueryHit>();
+        }
+        var ordered = fused.Values.OrderByDescending(f => f.Score).ToList();
+        var results = new List<QueryHit>(topK);
+        foreach (var candidate in ordered)
+        {
+            if (results.Count >= topK)
+            {
+                break;
+            }
+            if (filters.MaxDistance.HasValue && !double.IsNaN(candidate.Distance)
+                && candidate.Distance > filters.MaxDistance.Value)
+            {
+                continue;
+            }
+            var hit = await TryProjectHitAsync(candidate, filters, cancellationToken);
+            if (hit is not null)
+            {
+                results.Add(hit);
+            }
+        }
+        return results;
+    }
+
+    private async Task<QueryHit?> TryProjectHitAsync(FusedCandidate candidate, QueryFilters filters, CancellationToken cancellationToken)
+    {
+        await using var cmd = Connection.CreateCommand();
+        cmd.Transaction = _transaction;
+        cmd.CommandText = ChunkProjectionSql;
+        cmd.Parameters.AddWithValue("$chunk_id", candidate.ChunkId);
+        BindChunkFilterParameters(cmd, filters);
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+        return new QueryHit(
+            ChunkId: reader.GetInt64(0),
+            RelativeFilePath: reader.GetString(1),
+            LineStart: reader.GetInt32(2),
+            LineEnd: reader.GetInt32(3),
+            FullyQualifiedSymbolName: reader.GetString(4),
+            SymbolKind: reader.GetString(5),
+            Distance: candidate.Distance,
+            FusedScore: candidate.Score,
+            SourceText: reader.GetString(6));
+    }
+
+    private static void BindChunkFilterParameters(SqliteCommand cmd, QueryFilters filters)
+    {
+        cmd.Parameters.AddWithValue("$symbol_kind", (object?)filters.SymbolKind ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$project", (object?)filters.ContainingProjectName ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$namespace", (object?)filters.ContainingNamespace ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$is_async", filters.IsAsync.HasValue ? (filters.IsAsync.Value ? 1 : 0) : DBNull.Value);
+        cmd.Parameters.AddWithValue("$accessibility", (object?)filters.Accessibility ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$has_attr", (object?)filters.HasAttributeFullyQualifiedName ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$impl", (object?)filters.ImplementsInterfaceFullyQualifiedName ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$rt_contains", (object?)filters.ReturnTypeContains ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$exclude_tests", filters.ExcludeTests ? 1 : 0);
+        cmd.Parameters.AddWithValue("$exclude_ns", (object?)filters.ExcludeNamespaceContains ?? DBNull.Value);
+    }
+
+    private const string ChunkProjectionSql = @"SELECT
+    c.chunk_id,
+    c.relative_file_path,
+    c.start_line_number,
+    c.end_line_number,
+    c.fully_qualified_symbol_name,
+    c.symbol_kind,
+    c.source_text
+FROM code_chunks c
+WHERE c.chunk_id = $chunk_id
+  AND ($symbol_kind IS NULL OR c.symbol_kind = $symbol_kind)
   AND ($project IS NULL OR c.containing_project_name = $project)
   AND ($namespace IS NULL OR c.containing_namespace = $namespace)
   AND ($is_async IS NULL OR c.is_async = $is_async)
-ORDER BY cand.distance
-LIMIT $top_k";
+  AND ($accessibility IS NULL OR c.accessibility = $accessibility)
+  AND ($has_attr IS NULL OR EXISTS (SELECT 1 FROM chunk_attributes a WHERE a.chunk_id = c.chunk_id AND a.attribute_fully_qualified_name = $has_attr))
+  AND ($impl IS NULL OR EXISTS (SELECT 1 FROM chunk_implemented_interfaces i WHERE i.chunk_id = c.chunk_id AND i.interface_fully_qualified_name = $impl))
+  AND ($rt_contains IS NULL OR c.return_type_fully_qualified_name LIKE '%' || $rt_contains || '%')
+  AND ($exclude_tests = 0 OR c.containing_namespace IS NULL OR (c.containing_namespace NOT LIKE '%.Tests' AND c.containing_namespace NOT LIKE '%.Tests.%'))
+  AND ($exclude_ns IS NULL OR c.containing_namespace IS NULL OR c.containing_namespace NOT LIKE '%' || $exclude_ns || '%')";
+
+    private sealed record KnnRanked(long ChunkId, double Distance, int Rank);
+
+    private sealed record Bm25Ranked(long ChunkId, int Rank);
+
+    private sealed record FusedCandidate(long ChunkId, double Distance, double Score);
 }

--- a/src/CodeRag.Core/Indexing/VoyageEmbeddingClient.cs
+++ b/src/CodeRag.Core/Indexing/VoyageEmbeddingClient.cs
@@ -1,0 +1,190 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CodeRag.Core.Indexing.Interfaces;
+
+namespace CodeRag.Core.Indexing;
+
+public sealed class VoyageEmbeddingClient : IEmbeddingClient
+{
+    private const string EndpointUrl = "https://api.voyageai.com/v1/embeddings";
+    private const int ApproximateCharacterLimit = 30000;
+
+    private readonly HttpClient _httpClient;
+    private readonly string _apiKey;
+
+    public VoyageEmbeddingClient(HttpClient httpClient, string apiKey)
+    {
+        _httpClient = httpClient;
+        _apiKey = apiKey;
+    }
+
+    public int VectorDimensions => VoyageEmbeddingOptions.VectorDimensions;
+
+    public async Task<IReadOnlyList<ReadOnlyMemory<float>>> Embed(IReadOnlyList<string> inputs, EmbeddingInputType inputType, CancellationToken cancellationToken)
+    {
+        var results = new ReadOnlyMemory<float>[inputs.Count];
+        for (int batchStart = 0; batchStart < inputs.Count; batchStart += VoyageEmbeddingOptions.MaxBatchSize)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            int batchEnd = Math.Min(batchStart + VoyageEmbeddingOptions.MaxBatchSize, inputs.Count);
+            var batchInputs = inputs.Skip(batchStart).Take(batchEnd - batchStart).Select(TruncateForModel).ToList();
+            var batchVectors = await EmbedBatchWithRetry(batchInputs, inputType, cancellationToken);
+            for (int i = 0; i < batchVectors.Count; i++)
+            {
+                results[batchStart + i] = batchVectors[i];
+            }
+        }
+        return results;
+    }
+
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Retry policy must catch transient failures of any type")]
+    private async Task<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchWithRetry(IReadOnlyList<string> inputs, EmbeddingInputType inputType, CancellationToken cancellationToken)
+    {
+        Exception? lastError = null;
+        for (int attempt = 0; attempt < VoyageEmbeddingOptions.MaxRetryAttempts; attempt++)
+        {
+            try
+            {
+                return await EmbedBatchOnce(inputs, inputType, cancellationToken);
+            }
+            catch (Exception ex) when (IsRetriable(ex))
+            {
+                lastError = ex;
+                int delaySeconds = 1 << attempt;
+                await Task.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken);
+            }
+        }
+        throw new InvalidOperationException($"Voyage embed failed after {VoyageEmbeddingOptions.MaxRetryAttempts} attempts.", lastError);
+    }
+
+    private async Task<IReadOnlyList<ReadOnlyMemory<float>>> EmbedBatchOnce(IReadOnlyList<string> inputs, EmbeddingInputType inputType, CancellationToken cancellationToken)
+    {
+        using var request = BuildRequest(inputs, inputType);
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Voyage embed returned {(int)response.StatusCode} {response.StatusCode}: {body}");
+        }
+        var payload = await response.Content.ReadFromJsonAsync<VoyageEmbeddingResponse>(cancellationToken: cancellationToken)
+            ?? throw new InvalidOperationException("Voyage embed returned a null body.");
+        return ProjectVectors(payload, inputs.Count);
+    }
+
+    private HttpRequestMessage BuildRequest(IReadOnlyList<string> inputs, EmbeddingInputType inputType)
+    {
+        var body = new VoyageEmbeddingRequest
+        {
+            Input = inputs,
+            Model = VoyageEmbeddingOptions.ModelName,
+            InputType = ResolveInputTypeString(inputType),
+            OutputDimension = VoyageEmbeddingOptions.VectorDimensions,
+        };
+        var request = new HttpRequestMessage(HttpMethod.Post, EndpointUrl)
+        {
+            Content = JsonContent.Create(body, options: SerializerOptions),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+        return request;
+    }
+
+    private static IReadOnlyList<ReadOnlyMemory<float>> ProjectVectors(VoyageEmbeddingResponse payload, int expectedCount)
+    {
+        if (payload.Data is null)
+        {
+            throw new InvalidOperationException("Voyage embed response missing 'data' field.");
+        }
+        if (payload.Data.Count != expectedCount)
+        {
+            throw new InvalidOperationException(
+                string.Format(CultureInfo.InvariantCulture,
+                    "Voyage returned {0} embeddings for {1} inputs.",
+                    payload.Data.Count, expectedCount));
+        }
+        var vectors = new ReadOnlyMemory<float>[expectedCount];
+        foreach (var item in payload.Data)
+        {
+            if (item.Embedding is null)
+            {
+                throw new InvalidOperationException("Voyage embed response contained a null embedding.");
+            }
+            if (item.Index < 0 || item.Index >= expectedCount)
+            {
+                throw new InvalidOperationException(
+                    string.Format(CultureInfo.InvariantCulture, "Voyage returned embedding with out-of-range index {0}.", item.Index));
+            }
+            vectors[item.Index] = item.Embedding.ToArray();
+        }
+        return vectors;
+    }
+
+    private static string ResolveInputTypeString(EmbeddingInputType inputType) => inputType switch
+    {
+        EmbeddingInputType.Query => "query",
+        _ => "document",
+    };
+
+    private static bool IsRetriable(Exception ex)
+    {
+        if (ex is HttpRequestException || ex is TaskCanceledException)
+        {
+            return true;
+        }
+        var message = ex.Message ?? string.Empty;
+        return message.Contains("429", StringComparison.Ordinal)
+            || message.Contains("500", StringComparison.Ordinal)
+            || message.Contains("502", StringComparison.Ordinal)
+            || message.Contains("503", StringComparison.Ordinal)
+            || message.Contains("504", StringComparison.Ordinal)
+            || message.Contains("Internal", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string TruncateForModel(string input)
+    {
+        if (input.Length <= ApproximateCharacterLimit) { return input; }
+        return input[..ApproximateCharacterLimit];
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private sealed record VoyageEmbeddingRequest
+    {
+        [JsonPropertyName("input")]
+        public IReadOnlyList<string>? Input { get; init; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; init; }
+
+        [JsonPropertyName("input_type")]
+        public string? InputType { get; init; }
+
+        [JsonPropertyName("output_dimension")]
+        public int? OutputDimension { get; init; }
+    }
+
+    private sealed record VoyageEmbeddingResponse
+    {
+        [JsonPropertyName("data")]
+        public IReadOnlyList<VoyageEmbeddingItem>? Data { get; init; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; init; }
+    }
+
+    private sealed record VoyageEmbeddingItem
+    {
+        [JsonPropertyName("embedding")]
+        public IReadOnlyList<float>? Embedding { get; init; }
+
+        [JsonPropertyName("index")]
+        public int Index { get; init; }
+    }
+}

--- a/src/CodeRag.Core/Indexing/VoyageEmbeddingOptions.cs
+++ b/src/CodeRag.Core/Indexing/VoyageEmbeddingOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace CodeRag.Core.Indexing;
+
+public sealed record VoyageEmbeddingOptions
+{
+    public const string ModelName = "voyage-code-3";
+    public const int VectorDimensions = 1024;
+    public const int MaxBatchSize = 96;
+    public const int MaxRetryAttempts = 5;
+}

--- a/src/CodeRag.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeRag.Core/ServiceCollectionExtensions.cs
@@ -13,13 +13,34 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IReconciliationService, ReconciliationService>();
         services.AddTransient<IWorkspaceLoadingService, MsBuildWorkspaceLoadingService>();
         services.AddSingleton<IGitDiffService, CliGitDiffService>();
-        services.AddSingleton<IEmbeddingClient>(_ =>
-            new OpenAIEmbeddingClient(Environment.GetEnvironmentVariable("OPENAI_API_KEY") ?? "sk-not-configured"));
+        services.AddHttpClient();
+        services.AddSingleton<IEmbeddingClient>(sp =>
+        {
+            var raw = Environment.GetEnvironmentVariable("EMBEDDING_PROVIDER")?.Trim();
+            var provider = string.IsNullOrEmpty(raw) ? "voyage" : raw;
+            return BuildEmbeddingClient(sp, provider);
+        });
         services.AddSingleton(TimeProvider.System);
-        services.AddSingleton<Func<string, IIndexStore>>(_ => path => new SqliteIndexStore(path));
+        services.AddSingleton<Func<string, IIndexStore>>(sp =>
+        {
+            var embedding = sp.GetRequiredService<IEmbeddingClient>();
+            return path => new SqliteIndexStore(path, embedding.VectorDimensions);
+        });
         services.AddTransient<IndexingDependencies>();
         services.AddTransient<IIndexingService, IndexingService>();
         services.AddTransient<IQueryService, QueryService>();
         return services;
+    }
+
+    private static IEmbeddingClient BuildEmbeddingClient(IServiceProvider sp, string provider)
+    {
+        if (string.Equals(provider, "openai", StringComparison.OrdinalIgnoreCase))
+        {
+            var openAiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY") ?? "sk-not-configured";
+            return new OpenAIEmbeddingClient(openAiKey);
+        }
+        var http = sp.GetRequiredService<IHttpClientFactory>().CreateClient();
+        var voyageKey = Environment.GetEnvironmentVariable("VOYAGE_API_KEY") ?? "voyage-not-configured";
+        return new VoyageEmbeddingClient(http, voyageKey);
     }
 }

--- a/tests/CodeRag.Tests.Integration/Core/Indexing/Fakes/FakeEmbeddingClient.cs
+++ b/tests/CodeRag.Tests.Integration/Core/Indexing/Fakes/FakeEmbeddingClient.cs
@@ -1,19 +1,32 @@
 ﻿using System.Security.Cryptography;
 using System.Text;
+using CodeRag.Core.Indexing;
 using CodeRag.Core.Indexing.Interfaces;
 
 namespace CodeRag.Tests.Integration.Core.Indexing.Fakes;
 
 public sealed class FakeEmbeddingClient : IEmbeddingClient
 {
+    public int VectorDimensions { get; }
     public int CallCount { get; private set; }
     public int InputCount { get; private set; }
 
-    public Task<IReadOnlyList<ReadOnlyMemory<float>>> Embed(IReadOnlyList<string> inputs, CancellationToken cancellationToken)
+    public FakeEmbeddingClient()
+        : this(1024)
     {
+    }
+
+    public FakeEmbeddingClient(int vectorDimensions)
+    {
+        VectorDimensions = vectorDimensions;
+    }
+
+    public Task<IReadOnlyList<ReadOnlyMemory<float>>> Embed(IReadOnlyList<string> inputs, EmbeddingInputType inputType, CancellationToken cancellationToken)
+    {
+        _ = inputType;
         CallCount++;
         InputCount += inputs.Count;
-        var results = inputs.Select(input => (ReadOnlyMemory<float>)SeededVectorFor(input)).ToList();
+        var results = inputs.Select(input => (ReadOnlyMemory<float>)SeededVectorFor(input, VectorDimensions)).ToList();
         return Task.FromResult<IReadOnlyList<ReadOnlyMemory<float>>>(results);
     }
 
@@ -23,13 +36,13 @@ public sealed class FakeEmbeddingClient : IEmbeddingClient
         InputCount = 0;
     }
 
-    private static float[] SeededVectorFor(string input)
+    private static float[] SeededVectorFor(string input, int dim)
     {
         var seed = SHA256.HashData(Encoding.UTF8.GetBytes(input));
 #pragma warning disable CA5394
         var rng = new Random(BitConverter.ToInt32(seed, 0));
 #pragma warning restore CA5394
-        var v = new float[3072];
+        var v = new float[dim];
         for (int i = 0; i < v.Length; i++)
         {
 #pragma warning disable CA5394

--- a/tests/CodeRag.Tests.Integration/Core/Indexing/IndexingServiceTests.cs
+++ b/tests/CodeRag.Tests.Integration/Core/Indexing/IndexingServiceTests.cs
@@ -27,7 +27,8 @@ public class IndexingServiceTests
         var hashingService = new SourceTextHashingService();
         var extractor = new ChunkExtractor(hashingService);
         var reconciliationService = new ReconciliationService();
-        Func<string, IIndexStore> storeFactory = path => new SqliteIndexStore(path);
+        var embeddingDimension = _embedding.VectorDimensions;
+        Func<string, IIndexStore> storeFactory = path => new SqliteIndexStore(path, embeddingDimension);
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 5, 2, 12, 0, 0, TimeSpan.Zero));
 
         var deps = new IndexingDependencies(
@@ -61,13 +62,13 @@ public class IndexingServiceTests
         result.UpdatedChunks.Should().Be(0);
         result.DeletedChunks.Should().Be(0);
 
-        using var verify = new SqliteIndexStore(_dbPath);
+        using var verify = new SqliteIndexStore(_dbPath, _embedding.VectorDimensions);
         await verify.OpenAsync(CancellationToken.None);
         var meta = await verify.TryGetMetadataAsync(CancellationToken.None);
         meta.Should().NotBeNull();
         meta!.IndexedAtCommitSha.Should().Be(_git.HeadSha);
-        meta.EmbeddingModelName.Should().Be(EmbeddingOptions.ModelName);
-        meta.EmbeddingVectorDimensions.Should().Be(EmbeddingOptions.VectorDimensions);
+        meta.EmbeddingModelName.Should().Be(VoyageEmbeddingOptions.ModelName);
+        meta.EmbeddingVectorDimensions.Should().Be(_embedding.VectorDimensions);
     }
 
     [Test]
@@ -131,7 +132,7 @@ public class IndexingServiceTests
 
         result.DeletedChunks.Should().BeGreaterThan(0);
 
-        using var verify = new SqliteIndexStore(_dbPath);
+        using var verify = new SqliteIndexStore(_dbPath, _embedding.VectorDimensions);
         await verify.OpenAsync(CancellationToken.None);
         IIndexStore verifyStore = verify;
         var summaries = await verifyStore.GetChunkSummariesForFileAsync(relativePath, CancellationToken.None);
@@ -172,7 +173,7 @@ public class IndexingServiceTests
     {
         await RunAsync();
 
-        using var verify = new SqliteIndexStore(_dbPath);
+        using var verify = new SqliteIndexStore(_dbPath, _embedding.VectorDimensions);
         await verify.OpenAsync(CancellationToken.None);
         await using var cmd = verify.Connection.CreateCommand();
         cmd.CommandText = @"

--- a/tests/CodeRag.Tests.Integration/Core/Indexing/QueryServiceTests.cs
+++ b/tests/CodeRag.Tests.Integration/Core/Indexing/QueryServiceTests.cs
@@ -27,7 +27,8 @@ public class QueryServiceTests
         var hashingService = new SourceTextHashingService();
         var extractor = new ChunkExtractor(hashingService);
         var reconciliationService = new ReconciliationService();
-        Func<string, IIndexStore> storeFactory = path => new SqliteIndexStore(path);
+        var embeddingDimension = _embedding.VectorDimensions;
+        Func<string, IIndexStore> storeFactory = path => new SqliteIndexStore(path, embeddingDimension);
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 5, 2, 12, 0, 0, TimeSpan.Zero));
 
         var deps = new IndexingDependencies(
@@ -52,23 +53,27 @@ public class QueryServiceTests
         _fixture.Dispose();
     }
 
+    private static QueryFilters NoFilters() =>
+        new(null, null, null, null, null, null, null, null, ExcludeTests: false, null, null);
+
     [Test]
-    public async Task Should_return_chunks_ranked_by_embedding_similarity()
+    public async Task Should_return_chunks_ranked_by_fused_score()
     {
         var hits = await _queryService.Run(
-            new QueryRequest(_dbPath, "find a user by name", 5, new QueryFilters(null, null, null, null)),
+            new QueryRequest(_dbPath, "find a user by name", 5, NoFilters()),
             CancellationToken.None);
 
         hits.Should().NotBeEmpty();
-        hits.Should().BeInAscendingOrder(h => h.Distance);
+        hits.Should().BeInDescendingOrder(h => h.FusedScore);
         hits.Count.Should().BeLessThanOrEqualTo(5);
     }
 
     [Test]
     public async Task Should_apply_symbol_kind_filter()
     {
+        var filters = NoFilters() with { SymbolKind = "method" };
         var hits = await _queryService.Run(
-            new QueryRequest(_dbPath, "look up a record", 10, new QueryFilters("method", null, null, null)),
+            new QueryRequest(_dbPath, "look up a record", 10, filters),
             CancellationToken.None);
 
         hits.Should().NotBeEmpty();
@@ -78,11 +83,36 @@ public class QueryServiceTests
     [Test]
     public async Task Should_apply_is_async_filter()
     {
+        var filters = NoFilters() with { SymbolKind = "method", IsAsync = true };
         var hits = await _queryService.Run(
-            new QueryRequest(_dbPath, "asynchronous method", 20, new QueryFilters("method", null, null, IsAsync: true)),
+            new QueryRequest(_dbPath, "asynchronous method", 20, filters),
             CancellationToken.None);
 
         hits.Should().NotBeEmpty();
         hits.Should().Contain(h => h.FullyQualifiedSymbolName.Contains("FindAsync", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public async Task Should_blend_bm25_and_vector_scores_via_rrf()
+    {
+        var filters = NoFilters();
+        var hits = await _queryService.Run(
+            new QueryRequest(_dbPath, "FindAsync UserService", 20, filters),
+            CancellationToken.None);
+
+        hits.Should().NotBeEmpty();
+        hits.Should().Contain(h => h.FullyQualifiedSymbolName.Contains("FindAsync", StringComparison.Ordinal));
+        hits.Should().OnlyContain(h => h.FusedScore > 0);
+    }
+
+    [Test]
+    public async Task Should_apply_exclude_tests_filter()
+    {
+        var filters = NoFilters() with { ExcludeTests = true };
+        var hits = await _queryService.Run(
+            new QueryRequest(_dbPath, "user service", 50, filters),
+            CancellationToken.None);
+
+        hits.Should().OnlyContain(h => !h.FullyQualifiedSymbolName.Contains(".Tests.", StringComparison.Ordinal));
     }
 }

--- a/tests/CodeRag.Tests.Unit/Core/Indexing/ChunkExtractorTests.cs
+++ b/tests/CodeRag.Tests.Unit/Core/Indexing/ChunkExtractorTests.cs
@@ -255,6 +255,31 @@ public class ChunkExtractorTests
     }
 
     [Test]
+    public void Should_capture_xml_doc_summary_when_present()
+    {
+        var src = @"
+            namespace Acme;
+            public class Foo
+            {
+                /// <summary>does important work</summary>
+                public void Run() { }
+            }
+        ";
+        var tree = CSharpSyntaxTree.ParseText(src, path: "C:/repo/src/Test.cs");
+        var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { tree },
+            new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+            compilationOptions);
+
+        var chunks = _extractor.Extract(compilation, tree, "TestProject", "TestAssembly", "C:/repo", CancellationToken.None);
+
+        var method = chunks.Single(c => c.SymbolKind == SymbolKinds.Method);
+        method.XmlDocSummary.Should().Be("does important work");
+    }
+
+    [Test]
     public void Should_skip_files_outside_repository_root()
     {
         var src = "namespace X; public class Foo { }";

--- a/tests/CodeRag.Tests.Unit/Core/Indexing/CodeChunkTests.cs
+++ b/tests/CodeRag.Tests.Unit/Core/Indexing/CodeChunkTests.cs
@@ -28,6 +28,7 @@ public class CodeChunkTests
             ReturnTypeFullyQualifiedName: null,
             ParameterCount: null,
             DocumentationCommentXml: null,
+            XmlDocSummary: null,
             SourceText: "public class Foo { }",
             SourceTextHash: "hash",
             Attributes: ImmutableArray<ChunkAttribute>.Empty,
@@ -36,5 +37,38 @@ public class CodeChunkTests
             GenericTypeParameters: ImmutableArray<ChunkGenericTypeParameter>.Empty);
 
         chunk.SymbolKind.Should().Be(SymbolKinds.Class);
+        chunk.XmlDocSummary.Should().BeNull();
+    }
+
+    [Test]
+    public void Should_carry_xml_doc_summary_when_provided()
+    {
+        var chunk = new CodeChunk(
+            ContainingProjectName: "CodeRag.Core",
+            ContainingAssemblyName: "CodeRag.Core",
+            RelativeFilePath: "src/Foo.cs",
+            StartLineNumber: 1,
+            EndLineNumber: 10,
+            SymbolKind: SymbolKinds.Method,
+            SymbolDisplayName: "DoStuff",
+            SymbolSignatureDisplay: "void DoStuff()",
+            FullyQualifiedSymbolName: "Foo.DoStuff",
+            ContainingNamespace: "Foo",
+            ParentSymbolFullyQualifiedName: "Foo",
+            Accessibility: Accessibilities.Public,
+            Modifiers: new ChunkModifiers(false, false, false, false, false, false, false, false, false, false, false, false),
+            BaseTypeFullyQualifiedName: null,
+            ReturnTypeFullyQualifiedName: null,
+            ParameterCount: 0,
+            DocumentationCommentXml: "<doc><summary>does the stuff</summary></doc>",
+            XmlDocSummary: "does the stuff",
+            SourceText: "public void DoStuff() { }",
+            SourceTextHash: "hash",
+            Attributes: ImmutableArray<ChunkAttribute>.Empty,
+            ImplementedInterfaceFullyQualifiedNames: ImmutableArray<string>.Empty,
+            Parameters: ImmutableArray<ChunkParameter>.Empty,
+            GenericTypeParameters: ImmutableArray<ChunkGenericTypeParameter>.Empty);
+
+        chunk.XmlDocSummary.Should().Be("does the stuff");
     }
 }

--- a/tests/CodeRag.Tests.Unit/Core/Indexing/OpenAIEmbeddingClientTests.cs
+++ b/tests/CodeRag.Tests.Unit/Core/Indexing/OpenAIEmbeddingClientTests.cs
@@ -11,5 +11,6 @@ public class OpenAIEmbeddingClientTests
     {
         var client = new OpenAIEmbeddingClient("sk-fake");
         client.Should().NotBeNull();
+        client.VectorDimensions.Should().Be(OpenAIEmbeddingOptions.VectorDimensions);
     }
 }

--- a/tests/CodeRag.Tests.Unit/Core/Indexing/SqliteIndexStoreTests.cs
+++ b/tests/CodeRag.Tests.Unit/Core/Indexing/SqliteIndexStoreTests.cs
@@ -7,6 +7,8 @@ namespace CodeRag.Tests.Unit.Core.Indexing;
 [TestFixture]
 public class SqliteIndexStoreTests
 {
+    private const int TestVectorDimensions = 1024;
+
     private string _dbPath = null!;
 
     [SetUp]
@@ -27,7 +29,7 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_create_schema_when_file_is_new()
     {
-        using var store = new SqliteIndexStore(_dbPath);
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         await store.OpenAsync(CancellationToken.None);
 
         var metadata = await store.TryGetMetadataAsync(CancellationToken.None);
@@ -39,17 +41,17 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_round_trip_metadata()
     {
-        using var store = new SqliteIndexStore(_dbPath);
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         await store.OpenAsync(CancellationToken.None);
 
         var written = new IndexMetadata(
-            SchemaVersion: 1,
+            SchemaVersion: 2,
             SolutionFilePath: "C:\\code\\foo.sln",
             RepositoryRootPath: "C:\\code",
             IndexedAtCommitSha: "abc123",
             IndexedAtUtc: new DateTimeOffset(2026, 5, 2, 12, 0, 0, TimeSpan.Zero),
-            EmbeddingModelName: "text-embedding-3-large",
-            EmbeddingVectorDimensions: 3072);
+            EmbeddingModelName: "voyage-code-3",
+            EmbeddingVectorDimensions: TestVectorDimensions);
         await store.SetMetadataAsync(written, CancellationToken.None);
 
         var read = await store.TryGetMetadataAsync(CancellationToken.None);
@@ -59,14 +61,14 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_throw_when_schema_version_does_not_match()
     {
-        using (var store = new SqliteIndexStore(_dbPath))
+        using (var store = new SqliteIndexStore(_dbPath, TestVectorDimensions))
         {
             await store.OpenAsync(CancellationToken.None);
-            var meta = new IndexMetadata(99, "x", "x", "x", DateTimeOffset.UtcNow, "x", 3072);
+            var meta = new IndexMetadata(99, "x", "x", "x", DateTimeOffset.UtcNow, "x", TestVectorDimensions);
             await store.SetMetadataAsync(meta, CancellationToken.None);
         }
 
-        using var reopened = new SqliteIndexStore(_dbPath);
+        using var reopened = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         var act = async () => await reopened.OpenAsync(CancellationToken.None);
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*schema version*99*");
@@ -75,7 +77,7 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_persist_all_columns_and_child_rows()
     {
-        using var store = new SqliteIndexStore(_dbPath);
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         await store.OpenAsync(CancellationToken.None);
 
         var chunk = TestChunks.SampleMethod();
@@ -89,7 +91,7 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_replace_child_rows()
     {
-        using var store = new SqliteIndexStore(_dbPath);
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         await store.OpenAsync(CancellationToken.None);
 
         var original = TestChunks.SampleMethod();
@@ -109,13 +111,13 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_persist_vector_keyed_by_chunk_id()
     {
-        using var store = new SqliteIndexStore(_dbPath);
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         await store.OpenAsync(CancellationToken.None);
 
         var chunk = TestChunks.SampleMethod();
         long id = await store.InsertChunkAsync(chunk, CancellationToken.None);
 
-        var vector = new float[3072];
+        var vector = new float[TestVectorDimensions];
         for (int i = 0; i < vector.Length; i++)
         {
             vector[i] = i * 0.001f;
@@ -128,7 +130,7 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_return_only_chunks_in_that_file()
     {
-        using var store = new SqliteIndexStore(_dbPath);
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         IIndexStore api = store;
         await store.OpenAsync(CancellationToken.None);
 
@@ -147,13 +149,13 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_remove_row_and_cascade_children()
     {
-        using var store = new SqliteIndexStore(_dbPath);
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         IIndexStore api = store;
         await store.OpenAsync(CancellationToken.None);
 
         var chunk = TestChunks.SampleMethod();
         long id = await store.InsertChunkAsync(chunk, CancellationToken.None);
-        await store.UpsertEmbeddingAsync(id, new float[3072], CancellationToken.None);
+        await store.UpsertEmbeddingAsync(id, new float[TestVectorDimensions], CancellationToken.None);
 
         await api.DeleteChunkAsync(id, CancellationToken.None);
 
@@ -165,7 +167,7 @@ public class SqliteIndexStoreTests
     [Test]
     public async Task Should_remove_every_chunk_in_that_file()
     {
-        using var store = new SqliteIndexStore(_dbPath);
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
         IIndexStore api = store;
         await store.OpenAsync(CancellationToken.None);
 

--- a/tests/CodeRag.Tests.Unit/Core/Indexing/TestChunks.cs
+++ b/tests/CodeRag.Tests.Unit/Core/Indexing/TestChunks.cs
@@ -23,6 +23,7 @@ internal static class TestChunks
         ReturnTypeFullyQualifiedName: "System.Threading.Tasks.Task<int>",
         ParameterCount: 1,
         DocumentationCommentXml: null,
+        XmlDocSummary: null,
         SourceText: "public async Task<int> RunAsync(CancellationToken ct) => 0;",
         SourceTextHash: "deadbeef",
         Attributes: ImmutableArray.Create(new ChunkAttribute("System.ObsoleteAttribute", "[\"deprecated\"]")),

--- a/tests/CodeRag.Tests.Unit/Core/Indexing/VoyageEmbeddingClientTests.cs
+++ b/tests/CodeRag.Tests.Unit/Core/Indexing/VoyageEmbeddingClientTests.cs
@@ -1,0 +1,18 @@
+﻿using CodeRag.Core.Indexing;
+using FluentAssertions;
+
+namespace CodeRag.Tests.Unit.Core.Indexing;
+
+[TestFixture]
+public class VoyageEmbeddingClientTests
+{
+    [Test]
+    public void Should_construct_with_an_http_client_and_a_dummy_api_key()
+    {
+        using var http = new HttpClient();
+        var client = new VoyageEmbeddingClient(http, "voyage-fake");
+
+        client.Should().NotBeNull();
+        client.VectorDimensions.Should().Be(VoyageEmbeddingOptions.VectorDimensions);
+    }
+}


### PR DESCRIPTION
## Summary
Closes #12.

- Switch embedding pipeline to support code-specific models. New `VoyageEmbeddingClient` (voyage-code-3, 1024 dim) alongside existing `OpenAIEmbeddingClient` (text-embedding-3-large, 3072 dim). Provider chosen via `EMBEDDING_PROVIDER=voyage|openai` env var.
- Enrich embedding input via `EmbeddingTextBuilder` — prepends FQN/Kind/Parent/Signature/Summary metadata before the chunk body so the embedding sees structural context, not just raw code.
- Hybrid retrieval: KNN top-200 + FTS5 BM25 top-200 fused via Reciprocal Rank Fusion (k=60). Falls back to pure vector if BM25 query sanitizes to empty.
- Schema parameterized by embedding dimension at index-creation time. v1 → v2 schema migration is rejected with a clear "delete and re-run" message.
- Extract XML doc summaries via `symbol.GetDocumentationCommentXml()` so summaries are searchable.
- Seven new query filters: `--accessibility`, `--has-attribute`, `--implements`, `--return-type-contains`, `--exclude-tests`, `--exclude-namespace`, `--max-distance`.

## Smoke test (gtav-factions, 7,911 chunks)
- BM25 hybrid lifts exact-name matches to fused-score ceiling (~0.0325 ≈ RRF max for rank 1+1).
- All seven new filters verified end-to-end.
- `--max-distance 0.4` for "rubber-band difficulty" returns 0 hits — confident absence; no such system exists.
- Semantic bridge confirmed: query "rubber-band" surfaces `ZoneLeashEnforcer` via embedding similarity even though the codebase never uses the term.

## Known limitations
- `--implements` only matches direct interfaces; transitive `AllInterfaces` is a one-line follow-up.
- Voyage path is built-to-spec but not yet exercised against the live API.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` (Unit + Architecture) green
- [x] Re-index 7,911-chunk repo on v2 schema
- [x] Manual smoke of BM25 + each new filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)