### PR TITLE
feat(mcp): stdio MCP server exposing 4 code-navigation tools (#11)

### DIFF
--- a/CodeRag.slnx
+++ b/CodeRag.slnx
@@ -3,6 +3,7 @@
     <Project Path="src/CodeRag.Analyzers/CodeRag.Analyzers.csproj" />
     <Project Path="src/CodeRag.Cli/CodeRag.Cli.csproj" />
     <Project Path="src/CodeRag.Core/CodeRag.Core.csproj" />
+    <Project Path="src/CodeRag.Mcp/CodeRag.Mcp.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/CodeRag.Tests.Analyzers/CodeRag.Tests.Analyzers.csproj" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-  <ItemGroup Condition="'$(MSBuildProjectName)' == 'CodeRag.Cli' OR '$(MSBuildProjectName)' == 'CodeRag.Tests.Integration' OR '$(MSBuildProjectName)' == 'CodeRag.Tests.Unit'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'CodeRag.Cli' OR '$(MSBuildProjectName)' == 'CodeRag.Mcp' OR '$(MSBuildProjectName)' == 'CodeRag.Tests.Integration' OR '$(MSBuildProjectName)' == 'CodeRag.Tests.Unit'">
     <None Include="$(MSBuildThisFileDirectory)external\sqlite-vec\runtimes\win-x64\native\vec0.dll">
       <Link>runtimes\win-x64\native\vec0.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/CodeRag.Core/Indexing/CodeIndexLookupService.cs
+++ b/src/CodeRag.Core/Indexing/CodeIndexLookupService.cs
@@ -1,0 +1,47 @@
+﻿using CodeRag.Core.Indexing.Interfaces;
+
+namespace CodeRag.Core.Indexing;
+
+internal sealed class CodeIndexLookupService : ICodeIndexLookupService
+{
+    private readonly Func<string, IIndexStore> _storeFactory;
+
+    public CodeIndexLookupService(Func<string, IIndexStore> storeFactory)
+    {
+        _storeFactory = storeFactory;
+    }
+
+    public async Task<IReadOnlyList<SymbolHit>> FindSymbol(
+        string indexDatabasePath,
+        string nameOrFullyQualifiedName,
+        string? symbolKind,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        using var store = _storeFactory(indexDatabasePath);
+        await store.OpenAsync(cancellationToken);
+        return await store.FindSymbolByName(nameOrFullyQualifiedName, symbolKind, limit, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SymbolHit>> ListImplementations(
+        string indexDatabasePath,
+        string interfaceFullyQualifiedName,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        using var store = _storeFactory(indexDatabasePath);
+        await store.OpenAsync(cancellationToken);
+        return await store.ListImplementations(interfaceFullyQualifiedName, limit, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SymbolHit>> ListAttributedWith(
+        string indexDatabasePath,
+        string attributeFullyQualifiedName,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        using var store = _storeFactory(indexDatabasePath);
+        await store.OpenAsync(cancellationToken);
+        return await store.ListAttributedWith(attributeFullyQualifiedName, limit, cancellationToken);
+    }
+}

--- a/src/CodeRag.Core/Indexing/IIndexStore.cs
+++ b/src/CodeRag.Core/Indexing/IIndexStore.cs
@@ -25,4 +25,20 @@ internal interface IIndexStore : IDisposable
         QueryFilters filters,
         int topK,
         CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SymbolHit>> FindSymbolByName(
+        string nameOrFullyQualifiedName,
+        string? symbolKind,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SymbolHit>> ListImplementations(
+        string interfaceFullyQualifiedName,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SymbolHit>> ListAttributedWith(
+        string attributeFullyQualifiedName,
+        int limit,
+        CancellationToken cancellationToken);
 }

--- a/src/CodeRag.Core/Indexing/Interfaces/ICodeIndexLookupService.cs
+++ b/src/CodeRag.Core/Indexing/Interfaces/ICodeIndexLookupService.cs
@@ -1,0 +1,23 @@
+﻿namespace CodeRag.Core.Indexing.Interfaces;
+
+public interface ICodeIndexLookupService
+{
+    Task<IReadOnlyList<SymbolHit>> FindSymbol(
+        string indexDatabasePath,
+        string nameOrFullyQualifiedName,
+        string? symbolKind,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SymbolHit>> ListImplementations(
+        string indexDatabasePath,
+        string interfaceFullyQualifiedName,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SymbolHit>> ListAttributedWith(
+        string indexDatabasePath,
+        string attributeFullyQualifiedName,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/src/CodeRag.Core/Indexing/SqliteIndexStore.cs
+++ b/src/CodeRag.Core/Indexing/SqliteIndexStore.cs
@@ -825,6 +825,107 @@ WHERE c.chunk_id = $chunk_id
   AND ($exclude_tests = 0 OR c.containing_namespace IS NULL OR (c.containing_namespace NOT LIKE '%.Tests' AND c.containing_namespace NOT LIKE '%.Tests.%'))
   AND ($exclude_ns IS NULL OR c.containing_namespace IS NULL OR c.containing_namespace NOT LIKE '%' || $exclude_ns || '%')";
 
+    async Task<IReadOnlyList<SymbolHit>> IIndexStore.FindSymbolByName(
+        string nameOrFullyQualifiedName,
+        string? symbolKind,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        const string sql = SymbolProjectionPrefix + @"
+WHERE (c.symbol_display_name = $name
+       OR c.fully_qualified_symbol_name = $name
+       OR c.fully_qualified_symbol_name LIKE '%.' || $name
+       OR c.fully_qualified_symbol_name LIKE '%.' || $name || '(%')
+  AND ($kind IS NULL OR c.symbol_kind = $kind)
+ORDER BY length(c.fully_qualified_symbol_name), c.fully_qualified_symbol_name
+LIMIT $limit";
+        await using var cmd = Connection.CreateCommand();
+        cmd.Transaction = _transaction;
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("$name", nameOrFullyQualifiedName);
+        cmd.Parameters.AddWithValue("$kind", (object?)symbolKind ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$limit", limit);
+        return await ReadSymbolHitsAsync(cmd, cancellationToken);
+    }
+
+    async Task<IReadOnlyList<SymbolHit>> IIndexStore.ListImplementations(
+        string interfaceFullyQualifiedName,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        const string sql = SymbolProjectionPrefix + @"
+JOIN chunk_implemented_interfaces i ON i.chunk_id = c.chunk_id
+WHERE i.interface_fully_qualified_name = $iface
+ORDER BY c.fully_qualified_symbol_name
+LIMIT $limit";
+        await using var cmd = Connection.CreateCommand();
+        cmd.Transaction = _transaction;
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("$iface", interfaceFullyQualifiedName);
+        cmd.Parameters.AddWithValue("$limit", limit);
+        return await ReadSymbolHitsAsync(cmd, cancellationToken);
+    }
+
+    async Task<IReadOnlyList<SymbolHit>> IIndexStore.ListAttributedWith(
+        string attributeFullyQualifiedName,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        const string sql = SymbolProjectionPrefix + @"
+JOIN chunk_attributes a ON a.chunk_id = c.chunk_id
+WHERE a.attribute_fully_qualified_name = $attr
+ORDER BY c.fully_qualified_symbol_name
+LIMIT $limit";
+        await using var cmd = Connection.CreateCommand();
+        cmd.Transaction = _transaction;
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("$attr", attributeFullyQualifiedName);
+        cmd.Parameters.AddWithValue("$limit", limit);
+        return await ReadSymbolHitsAsync(cmd, cancellationToken);
+    }
+
+    [SuppressMessage(
+        "Security",
+        "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "SQL is composed from internal const fragments only; no user input.")]
+    private static async Task<IReadOnlyList<SymbolHit>> ReadSymbolHitsAsync(SqliteCommand cmd, CancellationToken cancellationToken)
+    {
+        var results = new List<SymbolHit>();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            results.Add(new SymbolHit(
+                ChunkId: reader.GetInt64(0),
+                RelativeFilePath: reader.GetString(1),
+                LineStart: reader.GetInt32(2),
+                LineEnd: reader.GetInt32(3),
+                FullyQualifiedSymbolName: reader.GetString(4),
+                SymbolDisplayName: reader.GetString(5),
+                SymbolKind: reader.GetString(6),
+                Accessibility: reader.GetString(7),
+                SymbolSignatureDisplay: reader.GetString(8),
+                ContainingNamespace: await reader.IsDBNullAsync(9, cancellationToken) ? null : reader.GetString(9),
+                ParentSymbolFullyQualifiedName: await reader.IsDBNullAsync(10, cancellationToken) ? null : reader.GetString(10),
+                XmlDocSummary: await reader.IsDBNullAsync(11, cancellationToken) ? null : reader.GetString(11)));
+        }
+        return results;
+    }
+
+    private const string SymbolProjectionPrefix = @"SELECT
+    c.chunk_id,
+    c.relative_file_path,
+    c.start_line_number,
+    c.end_line_number,
+    c.fully_qualified_symbol_name,
+    c.symbol_display_name,
+    c.symbol_kind,
+    c.accessibility,
+    c.symbol_signature_display,
+    c.containing_namespace,
+    c.parent_symbol_fully_qualified_name,
+    c.xml_doc_summary
+FROM code_chunks c";
+
     private sealed record KnnRanked(long ChunkId, double Distance, int Rank);
 
     private sealed record Bm25Ranked(long ChunkId, int Rank);

--- a/src/CodeRag.Core/Indexing/SymbolHit.cs
+++ b/src/CodeRag.Core/Indexing/SymbolHit.cs
@@ -1,0 +1,15 @@
+﻿namespace CodeRag.Core.Indexing;
+
+public sealed record SymbolHit(
+    long ChunkId,
+    string RelativeFilePath,
+    int LineStart,
+    int LineEnd,
+    string FullyQualifiedSymbolName,
+    string SymbolDisplayName,
+    string SymbolKind,
+    string Accessibility,
+    string SymbolSignatureDisplay,
+    string? ContainingNamespace,
+    string? ParentSymbolFullyQualifiedName,
+    string? XmlDocSummary);

--- a/src/CodeRag.Core/ServiceCollectionExtensions.cs
+++ b/src/CodeRag.Core/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IndexingDependencies>();
         services.AddTransient<IIndexingService, IndexingService>();
         services.AddTransient<IQueryService, QueryService>();
+        services.AddTransient<ICodeIndexLookupService, CodeIndexLookupService>();
         return services;
     }
 

--- a/src/CodeRag.Mcp/AssemblyMarker.cs
+++ b/src/CodeRag.Mcp/AssemblyMarker.cs
@@ -1,0 +1,3 @@
+﻿namespace CodeRag.Mcp;
+
+public static class AssemblyMarker;

--- a/src/CodeRag.Mcp/CodeRag.Mcp.csproj
+++ b/src/CodeRag.Mcp/CodeRag.Mcp.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CodeRag.Mcp</RootNamespace>
+    <AssemblyName>CodeRag.Mcp</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="ModelContextProtocol" Version="0.4.0-preview.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeRag.Core\CodeRag.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CodeRag.Mcp/IndexPathResolver.cs
+++ b/src/CodeRag.Mcp/IndexPathResolver.cs
@@ -1,0 +1,21 @@
+﻿namespace CodeRag.Mcp;
+
+internal static class IndexPathResolver
+{
+    public const string EnvVarName = "CODERAG_INDEX_PATH";
+
+    public static string Resolve(IReadOnlyList<string> args)
+    {
+        if (args.Count > 0 && !string.IsNullOrWhiteSpace(args[0]))
+        {
+            return Path.GetFullPath(args[0]);
+        }
+        var env = Environment.GetEnvironmentVariable(EnvVarName);
+        if (!string.IsNullOrWhiteSpace(env))
+        {
+            return Path.GetFullPath(env);
+        }
+        var localDefault = Path.Combine(Directory.GetCurrentDirectory(), ".coderag", "index.db");
+        return Path.GetFullPath(localDefault);
+    }
+}

--- a/src/CodeRag.Mcp/McpServerConfig.cs
+++ b/src/CodeRag.Mcp/McpServerConfig.cs
@@ -1,0 +1,3 @@
+﻿namespace CodeRag.Mcp;
+
+public sealed record McpServerConfig(string IndexDatabasePath);

--- a/src/CodeRag.Mcp/Program.cs
+++ b/src/CodeRag.Mcp/Program.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using CodeRag.Core;
+using CodeRag.Mcp;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+var indexPath = IndexPathResolver.Resolve(args);
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(opts => opts.LogToStandardErrorThreshold = LogLevel.Trace);
+
+builder.Services.AddCoreServices();
+builder.Services.AddSingleton(new McpServerConfig(indexPath));
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly(Assembly.GetExecutingAssembly());
+
+await builder.Build().RunAsync();

--- a/src/CodeRag.Mcp/Tools/CodeSearchTools.cs
+++ b/src/CodeRag.Mcp/Tools/CodeSearchTools.cs
@@ -1,0 +1,42 @@
+﻿using System.ComponentModel;
+using CodeRag.Core.Indexing;
+using CodeRag.Core.Indexing.Interfaces;
+using ModelContextProtocol.Server;
+
+namespace CodeRag.Mcp.Tools;
+
+[McpServerToolType]
+public static class CodeSearchTools
+{
+    [McpServerTool(Name = "search_code", ReadOnly = true, Idempotent = true)]
+    [Description("Hybrid semantic + lexical search over the indexed codebase. Returns ranked code chunks with file path, line range, fully-qualified name, kind, and source text. Filters compose. Use this when you don't know the exact symbol name or want to find conceptually-related code.")]
+    public static Task<IReadOnlyList<QueryHit>> SearchCode(
+        IQueryService queryService,
+        McpServerConfig config,
+        [Description("Natural-language or keyword query")] string query,
+        [Description("Max number of hits to return")] int topK = 10,
+        [Description("Filter by symbol kind: method, class, property, field, interface, struct, enum, record")] string? kind = null,
+        [Description("Filter by accessibility: public, internal, protected, private")] string? accessibility = null,
+        [Description("Filter to chunks decorated with this attribute (fully-qualified name)")] string? hasAttribute = null,
+        [Description("Filter to chunks implementing this interface (fully-qualified name, direct only)")] string? implements = null,
+        [Description("Filter to chunks whose return type contains this substring")] string? returnTypeContains = null,
+        [Description("Exclude chunks under a *.Tests* namespace (defaults true)")] bool excludeTests = true,
+        [Description("Drop hits with KNN distance above this value (e.g. 0.4 for high-confidence only)")] double? maxDistance = null,
+        CancellationToken cancellationToken = default)
+    {
+        var filters = new QueryFilters(
+            SymbolKind: kind,
+            ContainingProjectName: null,
+            ContainingNamespace: null,
+            IsAsync: null,
+            Accessibility: accessibility,
+            HasAttributeFullyQualifiedName: hasAttribute,
+            ImplementsInterfaceFullyQualifiedName: implements,
+            ReturnTypeContains: returnTypeContains,
+            ExcludeTests: excludeTests,
+            ExcludeNamespaceContains: null,
+            MaxDistance: maxDistance);
+        var request = new QueryRequest(config.IndexDatabasePath, query, topK, filters);
+        return queryService.Run(request, cancellationToken);
+    }
+}

--- a/src/CodeRag.Mcp/Tools/SymbolLookupTools.cs
+++ b/src/CodeRag.Mcp/Tools/SymbolLookupTools.cs
@@ -1,0 +1,47 @@
+﻿using System.ComponentModel;
+using CodeRag.Core.Indexing;
+using CodeRag.Core.Indexing.Interfaces;
+using ModelContextProtocol.Server;
+
+namespace CodeRag.Mcp.Tools;
+
+[McpServerToolType]
+public static class SymbolLookupTools
+{
+    [McpServerTool(Name = "find_symbol", ReadOnly = true, Idempotent = true)]
+    [Description("Look up a symbol by short name or fully-qualified name. Pure SQL lookup (no embeddings). Returns matching chunks ordered shortest-FQN first. Use this when you know the name and want exact navigation.")]
+    public static Task<IReadOnlyList<SymbolHit>> FindSymbol(
+        ICodeIndexLookupService lookup,
+        McpServerConfig config,
+        [Description("Short name (e.g. 'UserService') or fully-qualified name")] string nameOrFullyQualifiedName,
+        [Description("Optional kind filter: method, class, property, field, ...")] string? kind = null,
+        [Description("Max number of hits to return")] int limit = 20,
+        CancellationToken cancellationToken = default)
+    {
+        return lookup.FindSymbol(config.IndexDatabasePath, nameOrFullyQualifiedName, kind, limit, cancellationToken);
+    }
+
+    [McpServerTool(Name = "list_implementations", ReadOnly = true, Idempotent = true)]
+    [Description("List all chunks that directly implement the given interface (by fully-qualified name). Pure SQL lookup. Note: matches direct interfaces only, not transitive — a class extending a base that implements I will not match.")]
+    public static Task<IReadOnlyList<SymbolHit>> ListImplementations(
+        ICodeIndexLookupService lookup,
+        McpServerConfig config,
+        [Description("Fully-qualified interface name (e.g. 'MyApp.Services.IUserService')")] string interfaceFullyQualifiedName,
+        [Description("Max number of hits to return")] int limit = 50,
+        CancellationToken cancellationToken = default)
+    {
+        return lookup.ListImplementations(config.IndexDatabasePath, interfaceFullyQualifiedName, limit, cancellationToken);
+    }
+
+    [McpServerTool(Name = "list_attributed_with", ReadOnly = true, Idempotent = true)]
+    [Description("List all chunks decorated with the given attribute (by fully-qualified name). Pure SQL lookup. Useful for finding all [Obsolete], [TestFixture], [HttpGet], etc. usages.")]
+    public static Task<IReadOnlyList<SymbolHit>> ListAttributedWith(
+        ICodeIndexLookupService lookup,
+        McpServerConfig config,
+        [Description("Fully-qualified attribute name (e.g. 'System.ObsoleteAttribute')")] string attributeFullyQualifiedName,
+        [Description("Max number of hits to return")] int limit = 100,
+        CancellationToken cancellationToken = default)
+    {
+        return lookup.ListAttributedWith(config.IndexDatabasePath, attributeFullyQualifiedName, limit, cancellationToken);
+    }
+}

--- a/tests/CodeRag.Tests.Architecture/CodeRag.Tests.Architecture.csproj
+++ b/tests/CodeRag.Tests.Architecture/CodeRag.Tests.Architecture.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\CodeRag.Cli\CodeRag.Cli.csproj" />
     <ProjectReference Include="..\..\src\CodeRag.Core\CodeRag.Core.csproj" />
+    <ProjectReference Include="..\..\src\CodeRag.Mcp\CodeRag.Mcp.csproj" />
     <ProjectReference Include="..\CodeRag.Tests.Unit\CodeRag.Tests.Unit.csproj" />
     <ProjectReference Include="..\CodeRag.Tests.Integration\CodeRag.Tests.Integration.csproj" />
     <ProjectReference Include="..\CodeRag.Tests.Analyzers\CodeRag.Tests.Analyzers.csproj" />

--- a/tests/CodeRag.Tests.Architecture/CodeStructureTests.cs
+++ b/tests/CodeRag.Tests.Architecture/CodeStructureTests.cs
@@ -16,7 +16,7 @@ public class CodeStructureTests
     [Test]
     public void Should_have_test_fixture_for_every_public_class()
     {
-        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly };
+        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly, TestHelpers.McpAssembly };
 
         var testFixtureNames = TestHelpers.TestAssemblies
             .SelectMany(a => a.GetTypes())
@@ -52,10 +52,11 @@ public class CodeStructureTests
         var sourceAssemblyMap = new Dictionary<string, string>
         {
             ["CodeRag.Core"] = ".Core",
-            ["CodeRag.Cli"] = ".Cli"
+            ["CodeRag.Cli"] = ".Cli",
+            ["CodeRag.Mcp"] = ".Mcp"
         };
 
-        var sourceAssemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly };
+        var sourceAssemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly, TestHelpers.McpAssembly };
 
         var sourceClassToAssembly = new Dictionary<string, string>();
         foreach (var assembly in sourceAssemblies)
@@ -109,7 +110,7 @@ public class CodeStructureTests
     [Test]
     public void Should_not_return_arrays_from_public_methods()
     {
-        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly };
+        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly, TestHelpers.McpAssembly };
 
         var violations = assemblies
             .SelectMany(a => a.GetTypes())
@@ -144,7 +145,8 @@ public class CodeStructureTests
         var srcDirs = new[]
         {
             Path.Combine(solutionRoot, "src", "CodeRag.Core"),
-            Path.Combine(solutionRoot, "src", "CodeRag.Cli")
+            Path.Combine(solutionRoot, "src", "CodeRag.Cli"),
+            Path.Combine(solutionRoot, "src", "CodeRag.Mcp")
         };
 
         var violations = new List<string>();

--- a/tests/CodeRag.Tests.Architecture/LayerDependencyTests.cs
+++ b/tests/CodeRag.Tests.Architecture/LayerDependencyTests.cs
@@ -43,4 +43,17 @@ public class LayerDependencyTests
         firstPartyRefs.Should().BeEquivalentTo(new[] { "CodeRag.Core" },
             "Cli is the sole entry point and may only reference Core within first-party assemblies");
     }
+
+    [Test]
+    public void Should_keep_mcp_depending_only_on_first_party_core()
+    {
+        var mcpAssembly = Assembly.Load("CodeRag.Mcp");
+        var firstPartyRefs = mcpAssembly.GetReferencedAssemblies()
+            .Select(a => a.Name)
+            .Where(name => name?.StartsWith("CodeRag", StringComparison.Ordinal) == true)
+            .ToList();
+
+        firstPartyRefs.Should().BeEquivalentTo(new[] { "CodeRag.Core" },
+            "Mcp is a thin protocol shim and may only reference Core within first-party assemblies");
+    }
 }

--- a/tests/CodeRag.Tests.Architecture/NamingConventionTests.cs
+++ b/tests/CodeRag.Tests.Architecture/NamingConventionTests.cs
@@ -145,7 +145,7 @@ public class NamingConventionTests
     [Test]
     public void Should_not_use_async_suffix_on_method_names()
     {
-        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly };
+        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly, TestHelpers.McpAssembly };
 
         var violations = assemblies
             .SelectMany(a => a.GetTypes())
@@ -165,7 +165,7 @@ public class NamingConventionTests
     [Test]
     public void Should_use_recognised_role_suffix_on_concrete_classes()
     {
-        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly };
+        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly, TestHelpers.McpAssembly };
 
         var concreteClasses = assemblies
             .SelectMany(a => a.GetTypes())
@@ -191,7 +191,7 @@ public class NamingConventionTests
     [Test]
     public void Should_place_interfaces_in_interfaces_namespace()
     {
-        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly };
+        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly, TestHelpers.McpAssembly };
 
         var projectInterfaces = assemblies
             .SelectMany(a => a.GetTypes())

--- a/tests/CodeRag.Tests.Architecture/ServiceShapeTests.cs
+++ b/tests/CodeRag.Tests.Architecture/ServiceShapeTests.cs
@@ -44,7 +44,7 @@ public class ServiceShapeTests
     [Test]
     public void Should_inject_dependencies_as_interfaces_not_concrete_types()
     {
-        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly };
+        var assemblies = new[] { TestHelpers.CoreAssembly, TestHelpers.CliAssembly, TestHelpers.McpAssembly };
 
         var serviceClasses = assemblies
             .SelectMany(a => a.GetTypes())

--- a/tests/CodeRag.Tests.Architecture/TestHelpers.cs
+++ b/tests/CodeRag.Tests.Architecture/TestHelpers.cs
@@ -7,6 +7,7 @@ internal static class TestHelpers
 {
     public static Assembly CoreAssembly => typeof(Core.AssemblyMarker).Assembly;
     public static Assembly CliAssembly => typeof(Cli.AssemblyMarker).Assembly;
+    public static Assembly McpAssembly => typeof(Mcp.AssemblyMarker).Assembly;
 
     public static readonly Assembly[] TestAssemblies =
     [

--- a/tests/CodeRag.Tests.Integration/Core/Indexing/CodeIndexLookupServiceTests.cs
+++ b/tests/CodeRag.Tests.Integration/Core/Indexing/CodeIndexLookupServiceTests.cs
@@ -1,0 +1,91 @@
+﻿using CodeRag.Core.Indexing;
+using CodeRag.Tests.Integration.Core.Indexing.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace CodeRag.Tests.Integration.Core.Indexing;
+
+[TestFixture]
+public class CodeIndexLookupServiceTests
+{
+    private SampleSolutionFixture _fixture = null!;
+    private FakeEmbeddingClient _embedding = null!;
+    private StubGitDiffService _git = null!;
+    private MsBuildWorkspaceLoadingService _workspaceLoadingService = null!;
+    private string _dbPath = null!;
+    private CodeIndexLookupService _lookup = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _fixture = new SampleSolutionFixture();
+        _embedding = new FakeEmbeddingClient();
+        _git = new StubGitDiffService();
+        _dbPath = Path.Combine(_fixture.Root, ".coderag", "index.db");
+
+        _workspaceLoadingService = new MsBuildWorkspaceLoadingService();
+        var hashingService = new SourceTextHashingService();
+        var extractor = new ChunkExtractor(hashingService);
+        var reconciliationService = new ReconciliationService();
+        var embeddingDimension = _embedding.VectorDimensions;
+        Func<string, IIndexStore> storeFactory = path => new SqliteIndexStore(path, embeddingDimension);
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 5, 2, 12, 0, 0, TimeSpan.Zero));
+
+        var deps = new IndexingDependencies(
+            _workspaceLoadingService,
+            extractor,
+            _git,
+            _embedding,
+            storeFactory,
+            reconciliationService,
+            clock);
+
+        var indexingService = new IndexingService(deps);
+        await indexingService.Run(new IndexRunRequest(_fixture.SolutionPath, _dbPath), CancellationToken.None);
+
+        _lookup = new CodeIndexLookupService(storeFactory);
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await _workspaceLoadingService.DisposeAsync();
+        _fixture.Dispose();
+    }
+
+    [Test]
+    public async Task Should_find_symbol_by_short_name()
+    {
+        var hits = await _lookup.FindSymbol(_dbPath, "ConsoleLogger", null, 10, CancellationToken.None);
+
+        hits.Should().NotBeEmpty();
+        hits.Should().Contain(h => h.FullyQualifiedSymbolName.Contains("ConsoleLogger", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public async Task Should_filter_find_symbol_by_kind()
+    {
+        var hits = await _lookup.FindSymbol(_dbPath, "FindAsync", SymbolKinds.Method, 10, CancellationToken.None);
+
+        hits.Should().NotBeEmpty();
+        hits.Should().OnlyContain(h => h.SymbolKind == SymbolKinds.Method);
+    }
+
+    [Test]
+    public async Task Should_list_classes_implementing_interface()
+    {
+        var hits = await _lookup.ListImplementations(_dbPath, "Sample.Lib.ILogger", 10, CancellationToken.None);
+
+        hits.Should().NotBeEmpty();
+        hits.Should().Contain(h => h.SymbolDisplayName == "ConsoleLogger");
+    }
+
+    [Test]
+    public async Task Should_list_chunks_decorated_with_obsolete_attribute()
+    {
+        var hits = await _lookup.ListAttributedWith(_dbPath, "System.ObsoleteAttribute", 10, CancellationToken.None);
+
+        hits.Should().NotBeEmpty();
+        hits.Should().Contain(h => h.FullyQualifiedSymbolName.Contains("LegacyHelper.Format", StringComparison.Ordinal));
+    }
+}

--- a/tests/CodeRag.Tests.Unit/Core/Indexing/SqliteIndexStoreTests.cs
+++ b/tests/CodeRag.Tests.Unit/Core/Indexing/SqliteIndexStoreTests.cs
@@ -180,4 +180,116 @@ public class SqliteIndexStoreTests
         var summaries = await api.GetChunkSummariesForFileAsync(path, CancellationToken.None);
         summaries.Should().BeEmpty();
     }
+
+    [Test]
+    public async Task Should_find_symbol_by_short_name_or_fqn()
+    {
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
+        IIndexStore api = store;
+        await store.OpenAsync(CancellationToken.None);
+
+        var inner = TestChunks.SampleMethod() with
+        {
+            FullyQualifiedSymbolName = "Game.Inner.Foo.Run()",
+            SymbolDisplayName = "Run",
+        };
+        var outer = TestChunks.SampleMethod() with
+        {
+            FullyQualifiedSymbolName = "Game.Outer.Foo.Run()",
+            SymbolDisplayName = "Run",
+        };
+        await store.InsertChunkAsync(inner, CancellationToken.None);
+        await store.InsertChunkAsync(outer, CancellationToken.None);
+
+        var byShort = await api.FindSymbolByName("Run", null, 10, CancellationToken.None);
+        byShort.Should().HaveCount(2);
+
+        var byFqn = await api.FindSymbolByName("Game.Inner.Foo.Run()", null, 10, CancellationToken.None);
+        byFqn.Should().ContainSingle().Which.FullyQualifiedSymbolName.Should().Be("Game.Inner.Foo.Run()");
+    }
+
+    [Test]
+    public async Task Should_filter_find_symbol_by_kind()
+    {
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
+        IIndexStore api = store;
+        await store.OpenAsync(CancellationToken.None);
+
+        var method = TestChunks.SampleMethod() with
+        {
+            FullyQualifiedSymbolName = "X.Y.DoThing()",
+            SymbolDisplayName = "DoThing",
+            SymbolKind = SymbolKinds.Method,
+        };
+        var classChunk = TestChunks.SampleMethod() with
+        {
+            FullyQualifiedSymbolName = "X.Y.DoThing",
+            SymbolDisplayName = "DoThing",
+            SymbolKind = SymbolKinds.Class,
+        };
+        await store.InsertChunkAsync(method, CancellationToken.None);
+        await store.InsertChunkAsync(classChunk, CancellationToken.None);
+
+        var hits = await api.FindSymbolByName("DoThing", SymbolKinds.Class, 10, CancellationToken.None);
+
+        hits.Should().ContainSingle()
+            .Which.SymbolKind.Should().Be(SymbolKinds.Class);
+    }
+
+    [Test]
+    public async Task Should_list_chunks_implementing_interface()
+    {
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
+        IIndexStore api = store;
+        await store.OpenAsync(CancellationToken.None);
+
+        var implementer = TestChunks.SampleMethod() with
+        {
+            FullyQualifiedSymbolName = "X.MyService",
+            SymbolDisplayName = "MyService",
+            SymbolKind = SymbolKinds.Class,
+            ImplementedInterfaceFullyQualifiedNames = ImmutableArray.Create("X.IMyService"),
+        };
+        var unrelated = TestChunks.SampleMethod() with
+        {
+            FullyQualifiedSymbolName = "X.OtherService",
+            SymbolDisplayName = "OtherService",
+            SymbolKind = SymbolKinds.Class,
+        };
+        await store.InsertChunkAsync(implementer, CancellationToken.None);
+        await store.InsertChunkAsync(unrelated, CancellationToken.None);
+
+        var hits = await api.ListImplementations("X.IMyService", 10, CancellationToken.None);
+
+        hits.Should().ContainSingle()
+            .Which.FullyQualifiedSymbolName.Should().Be("X.MyService");
+    }
+
+    [Test]
+    public async Task Should_list_chunks_decorated_with_attribute()
+    {
+        using var store = new SqliteIndexStore(_dbPath, TestVectorDimensions);
+        IIndexStore api = store;
+        await store.OpenAsync(CancellationToken.None);
+
+        var decorated = TestChunks.SampleMethod() with
+        {
+            FullyQualifiedSymbolName = "X.Y.OldThing",
+            SymbolDisplayName = "OldThing",
+            Attributes = ImmutableArray.Create(new ChunkAttribute("System.ObsoleteAttribute", null)),
+        };
+        var plain = TestChunks.SampleMethod() with
+        {
+            FullyQualifiedSymbolName = "X.Y.NewThing",
+            SymbolDisplayName = "NewThing",
+            Attributes = ImmutableArray<ChunkAttribute>.Empty,
+        };
+        await store.InsertChunkAsync(decorated, CancellationToken.None);
+        await store.InsertChunkAsync(plain, CancellationToken.None);
+
+        var hits = await api.ListAttributedWith("System.ObsoleteAttribute", 10, CancellationToken.None);
+
+        hits.Should().ContainSingle()
+            .Which.FullyQualifiedSymbolName.Should().Be("X.Y.OldThing");
+    }
 }


### PR DESCRIPTION
## Summary
Closes #11.

Adds **CodeRag.Mcp** — a console exe wired through the official `ModelContextProtocol` C# SDK over stdio. Exposes the existing index to Claude (or any MCP client) via four tools:

| Tool | Backed by | Uses embeddings? |
|---|---|---|
| `search_code` | `IQueryService` | Yes (vector + BM25 hybrid) |
| `find_symbol` | `ICodeIndexLookupService` | No (pure SQL) |
| `list_implementations` | `ICodeIndexLookupService` | No (pure SQL) |
| `list_attributed_with` | `ICodeIndexLookupService` | No (pure SQL) |

The three SQL-backed tools are the load-bearing day-to-day surface — cheap, structured, trustworthy negative results. `search_code` is the icing for conceptual queries where you don't know the symbol name.

## Architecture additions
- New public `ICodeIndexLookupService` + `SymbolHit` record in Core.
- SQL paths added to `IIndexStore` as **explicit** interface implementations (keeps SqliteIndexStore under CI0004's 10-public-method cap).
- `Directory.Build.targets` now also copies sqlite-vec native binaries into the Mcp output.
- Architecture tests pick up `McpAssembly` across all relevant scopes; new `Should_keep_mcp_depending_only_on_first_party_core` mirrors the CLI guard.
- Index path resolves: positional arg → `CODERAG_INDEX_PATH` env var → `./.coderag/index.db`.
- Logging routes to stderr so stdout stays clean for JSON-RPC.

## Smoke test (gtav-factions index)
- `initialize` handshake completes.
- `tools/list` advertises all four tools with full input schemas.
- `tools/call find_symbol VictoryConditionService` returns the class with file:line, FQN, signature, namespace, and xmlDocSummary (`"Service for detecting and managing victory conditions. Victory is achieved when a faction controls 100% of all zones."`).
- `tools/call list_attributed_with System.ObsoleteAttribute` returns `[]` (no usages — confident negative).

## Test plan
- [x] `dotnet build CodeRag.slnx` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] Unit tests: 43/43 pass
- [x] Architecture tests: 20/20 pass (includes new `Should_keep_mcp_depending_only_on_first_party_core`)
- [x] Lookup integration tests: 4/4 pass
- [x] Real-world stdio handshake against gtav-factions

## Wiring it up in Claude Code
```jsonc
{
  "mcpServers": {
    "coderag": {
      "command": "C:/path/to/CodeRag.Mcp.exe",
      "args": ["C:/repo/.coderag/index.db"]
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)